### PR TITLE
Reduce disk use & re-run

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.sh text eol=lf
+*.bat text eol=crlf

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ __pycache__
 *.lprof
 .ipynb_checkpoints/
 *.html
+/scratch/

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 .vscode/
 __pycache__
+*.log
+*.out
 *.pyc
 *.prof
 *.lprof

--- a/Dvcfile
+++ b/Dvcfile
@@ -1,6 +1,6 @@
 deps:
 - path: eval-report.ml100k.ipynb
-  md5: 277c98cd6b18017c7d252b388b83af9b
+  md5: 5dc13758acb5136b1c101574433845ef
 - path: eval-report.ml20m.ipynb
-  md5: 5abcf170253509652a883d300e267329
-md5: e4cc965dec0057097010c7e6b31bfea9
+  md5: d1af3f1b02ad532810921f15ad841dfd
+md5: 90831615acdd17ae26948c8ddbe56b4f

--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ This experiment uses [DVC](https://dvc.org) to script the experiment, and is lai
 - `lkdemo` is a Python package containing support code (e.g. log configurations) and algorithm definitions
 - `data` contains data files and controls
 - `models` contains trained LensKit models to run recommendations on individual data sets
+- `data-split` contains cross-validation splits, produced by `split-data.py`.  These splits only contain the
+  test files, to save disk space - the train files can be obtained with `lkdemo.datasets.ds_diff`, as seen
+  in `run-algo.py`.
 - `output` contains the results of running LensKit train/test runs
 - Various Python scripts to run individual pieces of the analysis
 - Jupyter notebooks to analyze results

--- a/data-split/ml100k.dvc
+++ b/data-split/ml100k.dvc
@@ -1,11 +1,11 @@
-md5: 016d0f4afbe4b0bffdb4529a0be7d592
+md5: e600cca3c7cd246fbfd838d23cadddcd
 cmd: python split-data.py -o data-split/ml100k ml100k
 wdir: ..
 deps:
 - md5: 6e47046882bad158b0efbb84cd5cb987
   path: data/ml-100k/u.data
 outs:
-- md5: bada8b5fc3b766ba8d9d44f3b7bb0809.dir
+- md5: c3ee128c9719ac7520f29b4f5aa74137.dir
   path: data-split/ml100k
   cache: true
   metric: false

--- a/data-split/ml20m.dvc
+++ b/data-split/ml20m.dvc
@@ -1,11 +1,11 @@
-md5: 0450192f0af080dc78dcd39cbea1387e
+md5: f28fb1883d2c477b18548452b6b31685
 cmd: python split-data.py -o data-split/ml20m ml20m
 wdir: ..
 deps:
 - md5: f95d275e0f2edad2391e5ef864a46628
   path: data/ml-20m/ratings.csv
 outs:
-- md5: 056eb5375b3dc79783b7ea576d9c6da8.dir
+- md5: 9c82e3dbd6aa78110a4b914d904b5060.dir
   path: data-split/ml20m
   cache: true
   metric: false

--- a/eval-report.ipynb
+++ b/eval-report.ipynb
@@ -181,7 +181,7 @@
    "outputs": [],
    "source": [
     "test = []\n",
-    "for file in split_dir.glob(\"test-*.csv\"):\n",
+    "for file in split_dir.glob(\"test-*.csv.gz\"):\n",
     "    test.append(pd.read_csv(file, sep=','))\n",
     "\n",
     "test = pd.concat(test, ignore_index=True)"

--- a/eval-report.ml100k.ipynb
+++ b/eval-report.ml100k.ipynb
@@ -4,10 +4,10 @@
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.013969,
-     "end_time": "2020-03-22T18:56:04.810609",
+     "duration": 0.014994,
+     "end_time": "2020-03-23T18:53:18.231670",
      "exception": false,
-     "start_time": "2020-03-22T18:56:04.796640",
+     "start_time": "2020-03-23T18:53:18.216676",
      "status": "completed"
     },
     "tags": []
@@ -20,10 +20,10 @@
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.01401,
-     "end_time": "2020-03-22T18:56:04.839619",
+     "duration": 0.013997,
+     "end_time": "2020-03-23T18:53:18.260644",
      "exception": false,
-     "start_time": "2020-03-22T18:56:04.825609",
+     "start_time": "2020-03-23T18:53:18.246647",
      "status": "completed"
     },
     "tags": []
@@ -36,10 +36,10 @@
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.012972,
-     "end_time": "2020-03-22T18:56:04.866610",
+     "duration": 0.013999,
+     "end_time": "2020-03-23T18:53:18.289644",
      "exception": false,
-     "start_time": "2020-03-22T18:56:04.853638",
+     "start_time": "2020-03-23T18:53:18.275645",
      "status": "completed"
     },
     "tags": []
@@ -52,10 +52,10 @@
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.014,
-     "end_time": "2020-03-22T18:56:04.895610",
+     "duration": 0.015967,
+     "end_time": "2020-03-23T18:53:18.318644",
      "exception": false,
-     "start_time": "2020-03-22T18:56:04.881610",
+     "start_time": "2020-03-23T18:53:18.302677",
      "status": "completed"
     },
     "tags": []
@@ -70,10 +70,10 @@
    "execution_count": 1,
    "metadata": {
     "papermill": {
-     "duration": 0.018,
-     "end_time": "2020-03-22T18:56:04.927609",
+     "duration": 0.020031,
+     "end_time": "2020-03-23T18:53:18.352675",
      "exception": false,
-     "start_time": "2020-03-22T18:56:04.909609",
+     "start_time": "2020-03-23T18:53:18.332644",
      "status": "completed"
     },
     "tags": []
@@ -87,10 +87,10 @@
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.013,
-     "end_time": "2020-03-22T18:56:04.954610",
+     "duration": 0.015006,
+     "end_time": "2020-03-23T18:53:18.381652",
      "exception": false,
-     "start_time": "2020-03-22T18:56:04.941610",
+     "start_time": "2020-03-23T18:53:18.366646",
      "status": "completed"
     },
     "tags": []
@@ -104,10 +104,10 @@
    "execution_count": 2,
    "metadata": {
     "papermill": {
-     "duration": 0.799006,
-     "end_time": "2020-03-22T18:56:05.766616",
+     "duration": 0.806062,
+     "end_time": "2020-03-23T18:53:19.202708",
      "exception": false,
-     "start_time": "2020-03-22T18:56:04.967610",
+     "start_time": "2020-03-23T18:53:18.396646",
      "status": "completed"
     },
     "tags": []
@@ -127,10 +127,10 @@
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.013985,
-     "end_time": "2020-03-22T18:56:05.794609",
+     "duration": 0.016996,
+     "end_time": "2020-03-23T18:53:19.232703",
      "exception": false,
-     "start_time": "2020-03-22T18:56:05.780624",
+     "start_time": "2020-03-23T18:53:19.215707",
      "status": "completed"
     },
     "tags": []
@@ -144,10 +144,10 @@
    "execution_count": 3,
    "metadata": {
     "papermill": {
-     "duration": 0.864001,
-     "end_time": "2020-03-22T18:56:06.673608",
+     "duration": 0.900026,
+     "end_time": "2020-03-23T18:53:20.147710",
      "exception": false,
-     "start_time": "2020-03-22T18:56:05.809607",
+     "start_time": "2020-03-23T18:53:19.247684",
      "status": "completed"
     },
     "tags": []
@@ -171,10 +171,10 @@
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.016001,
-     "end_time": "2020-03-22T18:56:06.704609",
+     "duration": 0.014028,
+     "end_time": "2020-03-23T18:53:20.176710",
      "exception": false,
-     "start_time": "2020-03-22T18:56:06.688608",
+     "start_time": "2020-03-23T18:53:20.162682",
      "status": "completed"
     },
     "tags": []
@@ -187,10 +187,10 @@
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.012999,
-     "end_time": "2020-03-22T18:56:06.731608",
+     "duration": 0.014996,
+     "end_time": "2020-03-23T18:53:20.206708",
      "exception": false,
-     "start_time": "2020-03-22T18:56:06.718609",
+     "start_time": "2020-03-23T18:53:20.191712",
      "status": "completed"
     },
     "tags": []
@@ -204,10 +204,10 @@
    "execution_count": 4,
    "metadata": {
     "papermill": {
-     "duration": 0.017999,
-     "end_time": "2020-03-22T18:56:06.764608",
+     "duration": 0.018055,
+     "end_time": "2020-03-23T18:53:20.241736",
      "exception": false,
-     "start_time": "2020-03-22T18:56:06.746609",
+     "start_time": "2020-03-23T18:53:20.223681",
      "status": "completed"
     },
     "tags": [
@@ -224,10 +224,10 @@
    "execution_count": 5,
    "metadata": {
     "papermill": {
-     "duration": 0.053,
-     "end_time": "2020-03-22T18:56:06.830608",
+     "duration": 0.052,
+     "end_time": "2020-03-23T18:53:20.307679",
      "exception": false,
-     "start_time": "2020-03-22T18:56:06.777608",
+     "start_time": "2020-03-23T18:53:20.255679",
      "status": "completed"
     },
     "tags": [
@@ -245,10 +245,10 @@
    "execution_count": 6,
    "metadata": {
     "papermill": {
-     "duration": 0.019993,
-     "end_time": "2020-03-22T18:56:06.864607",
+     "duration": 0.019001,
+     "end_time": "2020-03-23T18:53:20.340679",
      "exception": false,
-     "start_time": "2020-03-22T18:56:06.844614",
+     "start_time": "2020-03-23T18:53:20.321678",
      "status": "completed"
     },
     "tags": []
@@ -263,10 +263,10 @@
    "execution_count": 7,
    "metadata": {
     "papermill": {
-     "duration": 0.02,
-     "end_time": "2020-03-22T18:56:06.898609",
+     "duration": 0.021003,
+     "end_time": "2020-03-23T18:53:20.377682",
      "exception": false,
-     "start_time": "2020-03-22T18:56:06.878609",
+     "start_time": "2020-03-23T18:53:20.356679",
      "status": "completed"
     },
     "tags": []
@@ -281,10 +281,10 @@
    "execution_count": 8,
    "metadata": {
     "papermill": {
-     "duration": 0.393001,
-     "end_time": "2020-03-22T18:56:07.305608",
+     "duration": 0.397027,
+     "end_time": "2020-03-23T18:53:20.789709",
      "exception": false,
-     "start_time": "2020-03-22T18:56:06.912607",
+     "start_time": "2020-03-23T18:53:20.392682",
      "status": "completed"
     },
     "tags": []
@@ -308,10 +308,10 @@
    "execution_count": 9,
    "metadata": {
     "papermill": {
-     "duration": 0.139914,
-     "end_time": "2020-03-22T18:56:07.459520",
+     "duration": 0.091998,
+     "end_time": "2020-03-23T18:53:20.895679",
      "exception": false,
-     "start_time": "2020-03-22T18:56:07.319606",
+     "start_time": "2020-03-23T18:53:20.803681",
      "status": "completed"
     },
     "tags": []
@@ -333,10 +333,10 @@
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.012,
-     "end_time": "2020-03-22T18:56:07.485519",
+     "duration": 0.013997,
+     "end_time": "2020-03-23T18:53:20.923680",
      "exception": false,
-     "start_time": "2020-03-22T18:56:07.473519",
+     "start_time": "2020-03-23T18:53:20.909683",
      "status": "completed"
     },
     "tags": []
@@ -350,10 +350,10 @@
    "execution_count": 10,
    "metadata": {
     "papermill": {
-     "duration": 0.018349,
-     "end_time": "2020-03-22T18:56:07.517868",
+     "duration": 0.021987,
+     "end_time": "2020-03-23T18:53:20.960679",
      "exception": false,
-     "start_time": "2020-03-22T18:56:07.499519",
+     "start_time": "2020-03-23T18:53:20.938692",
      "status": "completed"
     },
     "tags": []
@@ -369,10 +369,10 @@
    "execution_count": 11,
    "metadata": {
     "papermill": {
-     "duration": 0.026841,
-     "end_time": "2020-03-22T18:56:07.557709",
+     "duration": 0.03,
+     "end_time": "2020-03-23T18:53:21.004678",
      "exception": false,
-     "start_time": "2020-03-22T18:56:07.530868",
+     "start_time": "2020-03-23T18:53:20.974678",
      "status": "completed"
     },
     "tags": []
@@ -380,7 +380,7 @@
    "outputs": [],
    "source": [
     "test = []\n",
-    "for file in split_dir.glob(\"test-*.csv\"):\n",
+    "for file in split_dir.glob(\"test-*.csv.gz\"):\n",
     "    test.append(pd.read_csv(file, sep=','))\n",
     "\n",
     "test = pd.concat(test, ignore_index=True)"
@@ -390,10 +390,10 @@
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.013029,
-     "end_time": "2020-03-22T18:56:07.584688",
+     "duration": 0.013,
+     "end_time": "2020-03-23T18:53:21.030679",
      "exception": false,
-     "start_time": "2020-03-22T18:56:07.571659",
+     "start_time": "2020-03-23T18:53:21.017679",
      "status": "completed"
     },
     "tags": []
@@ -406,10 +406,10 @@
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.013,
-     "end_time": "2020-03-22T18:56:07.610659",
+     "duration": 0.014,
+     "end_time": "2020-03-23T18:53:21.058679",
      "exception": false,
-     "start_time": "2020-03-22T18:56:07.597659",
+     "start_time": "2020-03-23T18:53:21.044679",
      "status": "completed"
     },
     "tags": []
@@ -423,10 +423,10 @@
    "execution_count": 12,
    "metadata": {
     "papermill": {
-     "duration": 20.337965,
-     "end_time": "2020-03-22T18:56:27.962623",
+     "duration": 24.06996,
+     "end_time": "2020-03-23T18:53:45.141638",
      "exception": false,
-     "start_time": "2020-03-22T18:56:07.624658",
+     "start_time": "2020-03-23T18:53:21.071678",
      "status": "completed"
     },
     "tags": []
@@ -478,41 +478,41 @@
        "      <th rowspan=\"5\" valign=\"top\">ALS</th>\n",
        "      <th>1</th>\n",
        "      <td>100.0</td>\n",
-       "      <td>0.02</td>\n",
-       "      <td>0.016129</td>\n",
-       "      <td>0.079207</td>\n",
+       "      <td>0.01</td>\n",
+       "      <td>0.010204</td>\n",
+       "      <td>0.042241</td>\n",
        "      <td>5</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
        "      <td>100.0</td>\n",
-       "      <td>0.01</td>\n",
-       "      <td>0.012346</td>\n",
-       "      <td>0.037994</td>\n",
+       "      <td>0.03</td>\n",
+       "      <td>0.062500</td>\n",
+       "      <td>0.188168</td>\n",
        "      <td>5</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
        "      <td>100.0</td>\n",
-       "      <td>0.00</td>\n",
-       "      <td>0.000000</td>\n",
-       "      <td>0.000000</td>\n",
+       "      <td>0.01</td>\n",
+       "      <td>0.166667</td>\n",
+       "      <td>0.144719</td>\n",
        "      <td>5</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
        "      <td>100.0</td>\n",
-       "      <td>0.00</td>\n",
-       "      <td>0.000000</td>\n",
-       "      <td>0.000000</td>\n",
+       "      <td>0.01</td>\n",
+       "      <td>0.083333</td>\n",
+       "      <td>0.066111</td>\n",
        "      <td>5</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>5</th>\n",
        "      <td>100.0</td>\n",
-       "      <td>0.01</td>\n",
-       "      <td>0.015625</td>\n",
-       "      <td>0.097334</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
        "      <td>5</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
@@ -522,11 +522,11 @@
       "text/plain": [
        "                        nrecs  precision  recip_rank      ndcg  ntruth\n",
        "dataset algorithm user                                                \n",
-       "ml100k  ALS       1     100.0       0.02    0.016129  0.079207       5\n",
-       "                  2     100.0       0.01    0.012346  0.037994       5\n",
-       "                  3     100.0       0.00    0.000000  0.000000       5\n",
-       "                  4     100.0       0.00    0.000000  0.000000       5\n",
-       "                  5     100.0       0.01    0.015625  0.097334       5"
+       "ml100k  ALS       1     100.0       0.01    0.010204  0.042241       5\n",
+       "                  2     100.0       0.03    0.062500  0.188168       5\n",
+       "                  3     100.0       0.01    0.166667  0.144719       5\n",
+       "                  4     100.0       0.01    0.083333  0.066111       5\n",
+       "                  5     100.0       0.00    0.000000  0.000000       5"
       ]
      },
      "execution_count": 12,
@@ -549,10 +549,10 @@
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.01403,
-     "end_time": "2020-03-22T18:56:27.990654",
+     "duration": 0.015033,
+     "end_time": "2020-03-23T18:53:45.173670",
      "exception": false,
-     "start_time": "2020-03-22T18:56:27.976624",
+     "start_time": "2020-03-23T18:53:45.158637",
      "status": "completed"
     },
     "tags": []
@@ -566,10 +566,10 @@
    "execution_count": 13,
    "metadata": {
     "papermill": {
-     "duration": 0.027395,
-     "end_time": "2020-03-22T18:56:28.031058",
+     "duration": 0.032001,
+     "end_time": "2020-03-23T18:53:45.221639",
      "exception": false,
-     "start_time": "2020-03-22T18:56:28.003663",
+     "start_time": "2020-03-23T18:53:45.189638",
      "status": "completed"
     },
     "tags": []
@@ -608,35 +608,35 @@
        "      <td>ALS</td>\n",
        "      <td>1</td>\n",
        "      <td>precision</td>\n",
-       "      <td>0.020000</td>\n",
+       "      <td>0.010000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
        "      <td>ALS</td>\n",
        "      <td>1</td>\n",
        "      <td>recip_rank</td>\n",
-       "      <td>0.016129</td>\n",
+       "      <td>0.010204</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
        "      <td>ALS</td>\n",
        "      <td>1</td>\n",
        "      <td>ndcg</td>\n",
-       "      <td>0.079207</td>\n",
+       "      <td>0.042241</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
        "      <td>ALS</td>\n",
        "      <td>2</td>\n",
        "      <td>precision</td>\n",
-       "      <td>0.010000</td>\n",
+       "      <td>0.030000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
        "      <td>ALS</td>\n",
        "      <td>2</td>\n",
        "      <td>recip_rank</td>\n",
-       "      <td>0.012346</td>\n",
+       "      <td>0.062500</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -644,11 +644,11 @@
       ],
       "text/plain": [
        "  algorithm  user      metric       val\n",
-       "0       ALS     1   precision  0.020000\n",
-       "1       ALS     1  recip_rank  0.016129\n",
-       "2       ALS     1        ndcg  0.079207\n",
-       "3       ALS     2   precision  0.010000\n",
-       "4       ALS     2  recip_rank  0.012346"
+       "0       ALS     1   precision  0.010000\n",
+       "1       ALS     1  recip_rank  0.010204\n",
+       "2       ALS     1        ndcg  0.042241\n",
+       "3       ALS     2   precision  0.030000\n",
+       "4       ALS     2  recip_rank  0.062500"
       ]
      },
      "execution_count": 13,
@@ -666,10 +666,10 @@
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.012968,
-     "end_time": "2020-03-22T18:56:28.058025",
+     "duration": 0.016,
+     "end_time": "2020-03-23T18:53:45.254639",
      "exception": false,
-     "start_time": "2020-03-22T18:56:28.045057",
+     "start_time": "2020-03-23T18:53:45.238639",
      "status": "completed"
     },
     "tags": []
@@ -683,10 +683,10 @@
    "execution_count": 14,
    "metadata": {
     "papermill": {
-     "duration": 0.775384,
-     "end_time": "2020-03-22T18:56:28.847409",
+     "duration": 0.860996,
+     "end_time": "2020-03-23T18:53:46.131635",
      "exception": false,
-     "start_time": "2020-03-22T18:56:28.072025",
+     "start_time": "2020-03-23T18:53:45.270639",
      "status": "completed"
     },
     "tags": []
@@ -694,7 +694,7 @@
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAwIAAADQCAYAAAC0otYBAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjMsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+AADFEAAAgAElEQVR4nO3de7xcdXnv8c+XYEQIcvdQBYRq1KJQKBGtsUArUjwWsC0eQBHwUmpP0XrB1NZTpHh6xFiPWsUqVaqoFRVv0YMgVQGNUhO5g6JAuSSQEgggYESSPOePtYLDdifZe7JX9uw9n/frNa+Ztdbvt9Yze88za551TVUhSZIkabhsNtkBSJIkSdr0LAQkSZKkIWQhIEmSJA0hCwFJkiRpCFkISJIkSUPIQkCSJEkaQhYCGlWSfZL89/VMn5PknzZlTBtrQzEneWKSczdlTJIkTZSpsO5OckKSD05mDPoVCwGtyz7AqF8mSTavqsVV9fpNHFNvDEkyrs/vhmKuqtur6siNj06aPFPhh8C6JHltkuMmadk3J9lxMpYtTaCBXndr8FgITFNJdk/y4yQfTXJNkk8nOTjJwiQ/TbJ/226rJGclWZTk8iRHJJkJnAYcleSKJEclOTXJmUm+AZyd5KAkX2vnMSvJvya5OslVSf50I2M/IclXkpyf5Pokb+95Tz9K8iHgMmDXJIck+X6Sy5J8Psmstu2zk3wvyZVJfpBk6xExH9i+tyva9711O/9r2ulb9Lyny5P8fk9sX2xj+2mS+RvzXqUODMQPgSSbj7dPVX24qs7e1MuVBsU0WHePun5M8sokP0lyMTC3Z/x/S/Kldl19ZZLnteP/rv07XJjkM0lO3pjYtB5V5WMaPoDdgVXAXjQF3w+Bs4AARwBfbtv9H+DY9vW2wE+ArYATgA/2zO/Udh6Pa4cPAr7Wvn4X8L6ettuNEs97gStGebx1lLYnAHcAOwCPA64B5rTvaQ3w3LbdjsAlwFbt8F8DpwAzgZuAZ7fjHw9sPiLmrwJz29ez2um7A9e0494M/Gv7+hnArcAWbWw3Adu0w7cAu072/9vH9Hm0n8MfAx9tP/ufBg4GFgI/BfZv223V5vQi4PI2r2e2n9XlbX4d1ebumcA3gH8bkQezgH8FrgauAv50I2M/Afh8m1/fase9pY3xKuDve9oe1467EvhkO+5U4OT29UXA+4DvtX+H/dez3JHvcXfgOzQbDC4Dnte2O6id77nt3/jTQNppN7ffKY8Dzgf+bLI/Cz6G78HUX3f/2voR+I32e2mn9jtq4doYgc8Cb2hfz2j7zmmX8Thga5rvvZMn+38zXR9uOZne/rOqrgZIci3wzaqqJFfTfNkAHAIc3lNtbwHsto75LaiqlaOMPxg4eu1AVd0zskFVvXGcsV9YVXe3sX8ReD7wZeCWqrq0bfNcYE9gYRJovmC+DzwduKOqFrXL/lk7n975LwT+b5JPA1+sqiUjpj8f+EDb/8dJbgGe1k77ZlXd187zOuDJwG3jfH/S+jwVeClwIs2P6JfRfCYPB/4WeAnwNpof269Ksi3wA+DfaYrhOVV1EkCSU4H9gOdX1cokB/Us5++A+6pqr7btdiMDSfJe4PdHifGcqjp9lPG/C+xdVSuSHALMBvan+SGzIMkBwN1t/HOr6q4k26/j77BVVT2v7XMW8Kx1tGPEe9wSeGFV/SLJbOAzND8uAPYFngncTvM9MBf4bjttFnAOcHZt5J4JaSNM5XX3aOvHHYGLqmp5O/6z/Gp9+gc0GwWoqtXAfUmeD3xlbcxJvjrOGDQOFgLT20M9r9f0DK/hV//70GwFvL63Y5LnjDK/B9exnAC1vkD6+DExcn5rh3tjCE3BcMyIZe29oXiq6vQk/4/mEIpLkxwM/GLEvNel9++6GvNIE28q/xC4sKpW9MR4CM0eC2h+aM8Gfhs4t6ruapex4tfm0vhMO/2SJI9Psm1V3buOtr3v8THAB5PsQ5OjT+tp94OqWgKQ5Aqav+faQuArwPyq+vSY36008abyuntd68f1LmeUuLSJeI6ALgBel3ZzeJJ92/H30+ySG4tvACetHRhtq2JVvbGq9hnlMdoXCcALk2yf5HE0Wz8XjtLmUmBukqe2y90yydNodvk/Mcmz2/FbjzxuOMlTqurqqnoXsJjm8J9elwAvb9s+jeYH1vVIm8Z4fgiszaXdqupH65jfRv0Q6Dmfpvfx1jEsK8A7e2J8alV9bCzLba1rg8CGlvtG4L9oCo45NHsL11pfIb8QeNHa70NpgA3quns0/wEclGSHJI+h2du51jeBv2iXPyPJ42kK88PSnKs3C3jxOJalcbIQ0Dtotp5dleZE2Xe0478N7Ln2hKMNzON/A9u1JzZdyehbD8bru8AnaY4T/EJVLR7ZoN3NeALwmSRX0RQGz6iqX9IcG/2BNp4LabaW9npDT7wrga+PmP4hYEa7BfazwAlV9RDS4JgKPwQuAF6VX53E/6QkT6BZ+f+PJDu049d1aNBR7fTn0xzCdN8Y39c2NIcHrgFeQXPs8VicQnPY0ofG2F6aLIO67v41VXUHzbkK36c5fPGynsl/Bfx+u679IfDM9rDeBTTnD32RZmPdWHNf47T2JClpYCQ5gZ5jnKVhkmR3mpP5ntUOf7wdPrd3Wru37H3A82i2sN9cVX/U/qi+gOZHwjuB3wIeqKp/bOd3EM2Jd3/U/kA/g+b4+tU0J/N+cSNiP4ERuZvkr4DXtIMP0JzgeGOS42lOJF4NXF5VJ7TnMzxQVf+Y5CKaHw4H0pzw/6qq+sE6lvtIv3Z4NvAF4Oc0P4xeV1Wzet972+6DwOKq+niSm2n2HtxNcz7C8qqa1+/fQlL/ksyqqgfa830uAU6sqss21E/jZyGggWMhIKktBE4ebW+gpOktyb/RXAxkC+ATVfXOSQ5p2rIQkCQNHAsBSeqehYAkaUpI8kqaY4p7Layqv5yMeCRpqrMQkCRJkobQtLn++aGHHlrnn3/+ZIchqdH35RfNZWmg9JXL5rE0UNaZx9Pm8qF33XXXZIcgaQKYy9LUZx5LU8O0KQQkSZIkjZ2FgCRJkjSELAQkSZKkIWQhIEmSJA0hCwFJkiRpCE2by4dKkiQNs3nz5rFs2TJ23nln5s+fP9nhaAqwEJAkSZoGli1bxtKlSyc7DE0hHhokSZIkDSELAUmSJGkIWQhIkiRJQ8hCQJIkSRpCnZ4snORQ4P3ADOCjVXX6iOlvAl4DrAKWA6+qqlvaaauBq9umt1bV4V3GKkmSNAjmfmBuX/1m3juTzdiM2+69ra95LHzdwr6Wq6mrs0IgyQzgDOCFwBJgUZIFVXVdT7PLgTlV9fMkfwHMB45qp62sqn26ik+SJEkaZl0eGrQ/cENV3VRVvwTOAY7obVBV366qn7eDlwK7dBiPJEmSpFaXhcCTgNt6hpe049bl1cDXe4a3SLI4yaVJXjJahyQntm0WL1++fOMjljQpzGVp6jOPpamny0Igo4yrURsmxwJzgHf3jN6tquYALwPel+QpvzazqjOrak5Vzdlpp50mImZJk8BclqY+81iaerosBJYAu/YM7wLcPrJRkoOBtwGHV9VDa8dX1e3t803ARcC+HcYqSZIkDZUuC4FFwOwkeySZCRwNLOhtkGRf4CM0RcCdPeO3S/LY9vWOwFyg9yRjSZIk9agtizVbraG2HPUADOnXdHbVoKpaleQk4AKay4eeVVXXJjkNWFxVC2gOBZoFfD4J/Ooyob8FfCTJGppi5fQRVxuSJElSj4fnPjzZIWiK6fQ+AlV1HnDeiHGn9Lw+eB39vgfs1WVskiRJ0jDzzsKSJEnSELIQkCRJkoaQhYAkSZI0hDo9R0CSpOlo3rx5LFu2jJ133pn58+dPdjiS1BcLAUmSxmnZsmUsXbp0ssOQpI1iISBJcgu3JA0hCwFJklu4JWkIebKwJEmSNIQsBCRJkqQhZCEgSZIkDSELAUmSJGkIWQhIkiRJQ8hCQJIkSRpCFgKSJEnSEPI+ApKkofXBN3+1r3733vXgI8/9zOOk9xzW13IlaSK5R0CSJEkaQu4RkKRpZO4H5vbVb+a9M9mMzbjt3tv6msfC1y3sa7mSpMnjHgFJkiRpCHVaCCQ5NMn1SW5I8tZRpr8pyXVJrkryzSRP7pl2fJKfto/ju4xTkiRJGjadFQJJZgBnAC8C9gSOSbLniGaXA3Oqam/gXGB+23d74O3Ac4D9gbcn2a6rWCVJkqRh0+Uegf2BG6rqpqr6JXAOcERvg6r6dlX9vB28FNilff2HwIVVtaKq7gEuBA7tMFZJkiRpqHRZCDwJuK1neEk7bl1eDXx9PH2TnJhkcZLFy5cv38hwJU0Wc1ma+sxjaerpshDIKONq1IbJscAc4N3j6VtVZ1bVnKqas9NOO/UdqKTJZS5LU595rKlm3rx5HHfcccybN2+yQ5k0XV4+dAmwa8/wLsDtIxslORh4G3BgVT3U0/egEX0v6iRKSZIkDZ1ly5axdOnSyQ5jUnW5R2ARMDvJHklmAkcDC3obJNkX+AhweFXd2TPpAuCQJNu1Jwkf0o6TJEmSNAE62yNQVauSnETzA34GcFZVXZvkNGBxVS2gORRoFvD5JAC3VtXhVbUiyTtoigmA06pqRVexSpI0HlvNfPyjniVpKur0zsJVdR5w3ohxp/S8Png9fc8CzuouOknSWrVlsYY11JajnsqlEeY+5U8mOwRJ2midFgKSpKnh4bkPT3YIkqRNzEJAkiRJU9YH3/zVvvrde9eDjzz3M4+T3nNYX8sdJF2eLCxJkiRpQFkISJIkSUPIQkCSJEkaQhYCkiRJ0hCyEJAkSZKGkIWAJEmSNIS8fKgkSZKGjncItxCQJEnSEPIO4R4aJEmSJA0lCwFJkiRpCFkISJIkSUPIQkCSJEkaQhYCkiRJ0hCyEJAkSZKGkIWAJEmSNIQ6LQSSHJrk+iQ3JHnrKNMPSHJZklVJjhwxbXWSK9rHgi7jlCRJkoZNZzcUSzIDOAN4IbAEWJRkQVVd19PsVuAE4ORRZrGyqvbpKj5JkiRpmHV5Z+H9gRuq6iaAJOcARwCPFAJVdXM7bU2HcUiSJEkaoctDg54E3NYzvKQdN1ZbJFmc5NIkL5nY0CRJkqTh1uUegYwyrsbRf7equj3JbwLfSnJ1Vd34qAUkJwInAuy22279RyppUpnL0tRnHktTzzr3CCS5P8nPRnncn+RnY5j3EmDXnuFdgNvHGlhV3d4+3wRcBOw7Spszq2pOVc3ZaaedxjprSQPGXJamPvNYmnrWuUegqrbeyHkvAmYn2QNYChwNvGwsHZNsB/y8qh5KsiMwF5i/kfFIkiRJao35HIEkT0iy29rHhtpX1SrgJOAC4EfA56rq2iSnJTm8neezkywBXgp8JMm1bfffAhYnuRL4NnD6iKsNSZIkSdoIGzxHoP3R/h7gicCdwJNpftg/c0N9q+o84LwR407peb2I5pChkf2+B+y1oflLkiRJ6s9Y9gi8A3gu8JOq2gN4AbCw06gkSZIkdWoshcDDVXU3sFmSzarq24A3+pIkSZKmsLFcPvTeJLOA7wCfTnInsKrbsCRJkiR1aSx7BC4BtgX+CjgfuBE4rMugJEmSJHVrLIVAaK78cxEwC/hse6iQJEmSpClqg4VAVf19VT0T+EuaKwddnOTfO49MkiRJUmfGfB8BmkuHLgPuBp7QTTiSJEmSNoUNFgJJ/iLJRcA3gR2BP6uqvbsOTJIkSVJ3xnLVoCcDb6iqK7oORpIkSdKmscFCoKreuikCkSRJkrTpjOccAUmSJEnThIWAJEmSNIQsBCRJkqQhZCEgSZIkDSELAUmSJGkIWQhIkiRJQ8hCQJIkSRpCFgKSJEnSEOq0EEhyaJLrk9yQ5NduTJbkgCSXJVmV5MgR045P8tP2cXyXcUqSJEnDprNCIMkM4AzgRcCewDFJ9hzR7FbgBODfRvTdHng78Bxgf+DtSbbrKlZJkiRp2HS5R2B/4IaquqmqfgmcAxzR26Cqbq6qq4A1I/r+IXBhVa2oqnuAC4FDO4xVkiRJGipdFgJPAm7rGV7SjpuwvklOTLI4yeLly5f3HaikyWUuS1OfeSxNPV0WAhllXE1k36o6s6rmVNWcnXbaaVzBSRoc5rI09ZnH0tTTZSGwBNi1Z3gX4PZN0FeSJEnSBnRZCCwCZifZI8lM4GhgwRj7XgAckmS79iThQ9pxkiRJkiZAZ4VAVa0CTqL5Af8j4HNVdW2S05IcDpDk2UmWAC8FPpLk2rbvCuAdNMXEIuC0dpwkSZKkCbB5lzOvqvOA80aMO6Xn9SKaw35G63sWcFaX8UmSJEnDyjsLS5IkSUPIQkCSJEkaQhYCkiRJ0hDq9BwBSZKkfs2bN49ly5ax8847M3/+/MkOR5p2LAQkTUv+gJCmvmXLlrF06dLJDuPX+P2i6cJCQNK0NKg/ICRNfX6/aLrwHAFJkiRpCLlHQJIkdWq/t5zdV7+t77qfGcCtd93f1zx++O7j+lquNCwsBCRJ0lC69bS9+uq3asX2wOasWnFLX/PY7ZSr+1quNNE8NEiSJEkaQu4RkKRNyKuNSJIGhYWAJG1CXm1EGrs1M7d61LOkiWUhIGmgeZKhNLwenH3IZIcwqh23WAOsap+lqctCQJIkaRxO3vveyQ5BmhAWApIkSeqM50YNLgsBSZIkdcZzowaXhYAk9cHrj0uSpjrvIyBJkiQNoU73CCQ5FHg/MAP4aFWdPmL6Y4Gzgf2Au4GjqurmJLsDPwKub5teWlWv7TJWSdOLlx2UpIl18QEH9tVv5eYzIGHlkiV9zePASy7ua7nasM4KgSQzgDOAFwJLgEVJFlTVdT3NXg3cU1VPTXI08C7gqHbajVW1T1fxSZreBvWyg5IkDYouDw3aH7ihqm6qql8C5wBHjGhzBPCJ9vW5wAuSpMOYJEmSJNFtIfAk4Lae4SXtuFHbVNUq4D5gh3baHkkuT3Jxkt8bbQFJTkyyOMni5cuXT2z0kjYZc1ma+sxjrcu2VWxfxbZVkx2KRujyHIHRtuyP/ASsq80dwG5VdXeS/YAvJ3lmVf3sUQ2rzgTOBJgzZ46fLmmKGqZc9o6kmq6GKY81Pseu9vtuUHVZCCwBdu0Z3gW4fR1tliTZHNgGWFFVBTwEUFU/THIj8DRgcYfxSlLnvCOpJGlQdHlo0CJgdpI9kswEjgYWjGizADi+fX0k8K2qqiQ7tScbk+Q3gdnATR3GKkmSJA2VzvYIVNWqJCcBF9BcPvSsqro2yWnA4qpaAHwM+GSSG4AVNMUCwAHAaUlWAauB11bViq5ilSRJkgbBvHnzWLZsGTvvvDPz58/vdFmd3kegqs4Dzhsx7pSe178AXjpKvy8AX+gyNknS4NuUK0RJGgTLli1j6dKlm2RZnRYCkiRtjE25QpSkifQPxx7ZV78Vd97XPC+7o695vO1T5465rYWANopb6yRJkqYmCwFtFLfWSZIkTU0WAgJg7gfm9tVv5r0z2YzNuO3e2/qex8LXLeyrn6Sp4+IDDuyr38rNZ0DCyiVL+prHgZdc3NdyJWmybDFjs0c9d8lCQBultizWsIba0nvHSJIkbax9d9h6ky3LQkAb5eG5D092CJIkSepD9/scJEmSJA0c9whIm5BXWZLGZ9uqRz1LkiaOhYC0CXmVJWl8jl29ZrJDkKRpy0JA6sMH3/zVvvrde9eDjzz3O4+T3nNYX/0kSZJ6WQhIm9BWMx//qGdJkqTJYiEgbUJzn/Inkx2CpGnM85AkjYeFgCRJ04TnIUkaDwsBSZIGzD8ce2Rf/VbceV/zvOyOvubxtk+d29dyJU1NFgIjDOpu1UGNS5IkSVPTtC0E9nvL2X312/ranzLjoZ9x61339z2PH777uHVOu/W0vfqa55Lrtue/Vm7OqhW39D2P3U65uq9+kqSpYYsZmz3qWZLWZ9oWApoeLj7gwElb9oGXXDxpy5akfuy7w9aTHYKkKcRCYIQ1M7d61POg2HGLNcCq9lkaXb/HFU8Ejy2WJGlq6bQQSHIo8H5gBvDRqjp9xPTHAmcD+wF3A0dV1c3ttL8BXg2sBl5fVRd0GetaD84+ZFMsZtxO3vveyQ5BkiRJ00hnBxEmmQGcAbwI2BM4JsmeI5q9Grinqp4KvBd4V9t3T+Bo4JnAocCH2vlJkiRJmgBdnk20P3BDVd1UVb8EzgGOGNHmCOAT7etzgRckSTv+nKp6qKr+E7ihnZ8kSZKkCZCq6mbGyZHAoVX1mnb4FcBzquqknjbXtG2WtMM3As8BTgUurapPteM/Bny9qs4dsYwTgRPbwacD109Q+DsCd03QvCaScY2PcY3PRMZ1V1UdOtbG5vLAMK7xGYa4xpzL5vHAMK7xGYa41pnHXZ4jkFHGjaw61tVmLH2pqjOBM8cf2volWVxVcyZ6vhvLuMbHuMZnMuMylweDcY2PcT2aeTwYjGt8hj2uLg8NWgLs2jO8C3D7utok2RzYBlgxxr6SJEmS+tRlIbAImJ1kjyQzaU7+XTCizQLg+Pb1kcC3qjlWaQFwdJLHJtkDmA38oMNYJUmSpKHS2aFBVbUqyUnABTSXDz2rqq5NchqwuKoWAB8DPpnkBpo9AUe3fa9N8jngOmAV8JdVtbqrWEcx4bs2J4hxjY9xjc+gxrUxBvU9Gdf4GNf4DGpc/RrU92Nc42Nc47NJ4ursZGFJkiRJg6vLQ4MkSZIkDSgLAUmSJGkIDW0hkOSPk1SSZ7TDu7f3NRjZ7rlJ/iPJFUl+lOTUjuJZ3S7jyiSXJXleO/6JSc7dUP+uJHlgxPAbk/wiyTY94w5K8rVR+v5Rksvb93Rdkj/fFDG3y36gfR71/9rxstf+L69J8vkkW27K5W/IaH+TJKcmOTnJRUnmrK/toBmkXDaPJ9Zk5nG73IHNZfN4+NbJ5nHfyx/YPIbJz+WhLQSAY4Dv0p6gvB6fAE6sqn2AZwGf6yielVW1T1X9NvA3wDsBqur2qjqyo2X24xiaK0L98foaJXkMzYkuh7XvaV/gos6jGwxr/5fPAn4JvHayA5rmBimXzePpxVzedAYpj2Fq5LJ5PDbm8XoMZSGQZBYwF3g1G/7SeQJwB0BVra6q6zoOD+DxwD3w6Oqvff2ddutE7xaK30hySU/F+3tdBJXkKcAs4H/RfAGtz9Y0V6W6G6CqHqqqibrL5FTyHeCpAEne1P5/rknyhnbc7kl+nOQTSa5Kcu6gba0YZAOey+bx9GIud2TA8xgGMJfN476ZxyMMZSEAvAQ4v6p+AqxI8jvrafte4PokX0ry50m26Cimx7VfGj8GPgq8Y5Q2dwIvrKrfAY4C/qkd/zLggnYLyW8DV3QU4zHAZ2gS6elJnrCuhlW1guZ+ELck+UySlycZqs9bmpvkvQi4Osl+wCuB5wDPBf4syb5t06cDZ1bV3sDPgP85GfFOUYOWy+bxNGQud27Q8hgGP5fN43Eyj0c3dB+E1jHAOe3rc1hPNV1VpwFzgG/QJPf5HcW0dtfVM4BDgbOTZESbxwD/kuRq4PPAnu34RcAr0xwruVdV3d9RjEcD51TVGuCLwEvX17iqXgO8gOZmcCcDZ3UU16B5XJIrgMXArTT3y3g+8KWqerCqHqD5+63dSnRbVS1sX3+qbduldV0zuNYxbZCvMTxouWweTy+DnMvm8XCvk83jsRvkPIZJzuXObig2qJLsAPwB8KwkRXOzswI+tK4+VXUj8M9J/gVYnmSHqrq7qxir6vtJdgR2GjHpjcB/0Wxh2Az4Rdv+kiQHAC+muUHbu6vq7ImMKcneNHd4vrD9LpwJ3AScsYH3cjVN9f1J4D+BEyYyrgG1st0S9IhRViC9RiZ11yvsu4HtRozbnub/M3La9sBdHcfTl0HPZfN4WhjkXDaPh3SdbB6P2yDnMUxyLg/jHoEjgbOr6slVtXtV7Urzx95ltMZJXtzzgZkNrAbu7TLANFdNmEF7PF+PbYA72i0Ar2jbkOTJwJ1V9S80le76dqv26xjg1PZvtntVPRF4Urvs0d7DrCQH9YzaB7ilg7imikuAlyTZMslWNCd3faedtluS321frz1hrjPt1o87krwAIMn2NFu8vktzAtmxPZ/544FvdxnPRhjoXDaPp62ByGXzGBjedbJ5vPEGIo9h8nN56PYI0PxTTx8x7gvA39IcZ7ekZ/wbgT8F3pvk58Aq4OVVtbqDuNbuugIIcHxVrR5RtH4I+EKSl9J8EB5sxx8EvCXJw8ADwHEdxHc0zbF1vb7Ujv8P4AUj/nbHAPOSfARY2cZ6QgdxTQlVdVmSj9PslgX4aFVdnmR34EfA8e3f6qfAP2+CkI4Dzkjynnb476vqxiRnAs8Army3zi2muWLGIBrEXDaPp7kBy2XzeDjXyebxRhqwPIZJzOVUDfJhg9L01n7pfK29rJmkKcpclqa+YczjYTw0SJIkSRp67hGQJEmShpB7BCRJkqQhZCEgSZIkDSELAUmSJGkIWQhowiS5ub3pykTM67VJjmtfn5DkiV0sR9KjmcfS9GAuayyG8T4CGnBJNq+qD/eMOgG4Brh9ciKSNF7msTQ9mMvTm4WA+pLky8CuwBbA+6vqzBHT/w54OXAbze2wf1hV/5hkH+DDwJbAjcCrquqeJBcB3wPmAguSbE1zI5abgTnAp5OsBNbe7e91SQ4DHgO8tKp+nORUYA/gN4CnAW8Cnktz45WlwGFV9XAHfw5pSjKPpenBXFa/PDRI/XpVVe1H84Xw+iQ7rJ2QZA7N3R/3Bf6kbbPW2cBfV9XewNXA23umbVtVB1bV2jvrUVXn0txJ7+VVtU9VrWwn3VVVv0Nzx7+Te+bxFODFwBHAp4BvV9VeNHdTfPEEvG9pOjGPpenBXFZfLATUr9cnuRK4lGYrxOyeac8HvlJVK6vqfuCrAEm2ofliubht9wnggJ5+nx3H8r/YPv8Q2L1n/NfbLQxXAzOA89vxV49oJ8k8lqYLc1l98dAgjVuSg4CDgd+tqp+3uxC36G3S56wfHEfbh9rn1Tz6c/wQQFWtSfJw/eqOeWvw8y49wjyWpgdzWRvDPQLqxzbAPe0XzjNojvnr9V3gsCRbJJlFu/uvqu4D7knye227VwAXs2H3A1tPTG9UfgIAAAC1SURBVOiSWuaxND2Yy+qb1Zj6cT7w2iRXAdfT7Ip8RFUtSrIAuBK4heZ4wvvayccDH06yJXAT8MoxLO/jbZ/eE5MkbRzzWJoezGX1Lb/aSyNNnCSzquqB9svlEuDEqrpssuOSNHbmsTQ9mMtaF/cIqCtnJtmT5jjFT/iFI01J5rE0PZjLGpV7BCRJkqQh5MnCkiRJ0hCyEJAkSZKGkIWAJEmSNIQsBCRJkqQhZCEgSZIkDaH/D1iPRT0hnLeFAAAAAElFTkSuQmCC\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAwIAAADQCAYAAAC0otYBAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjMsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+AADFEAAAgAElEQVR4nO3de7xcdXnv8c+XYOQS5G6pAkI1alEo1IjWWKAVKR4L2BYPoCh4KbWnaL1gao+nSPH0qLEebRWrVKmiVlS8RQ+CVAUURRO5g6BAuSSwSyCAgBFJ8pw/1ooO251k78le2bP3fN6v17xm1lq/31rP7D3PzDyzfmutVBWSJEmShstmUx2AJEmSpE3PQkCSJEkaQhYCkiRJ0hCyEJAkSZKGkIWAJEmSNIQsBCRJkqQhZCGgMSXZN8l/W8/yeUn+eVPGtLE2FHOSxyU5e1PGJEnSZJkOn91Jjk/ygamMQb9iIaB12RcY880kyeZVtaSqXreJY+qNIUkm9PrdUMxVdXtVHbnx0UlTZzp8EViXJK9J8vIp2vbNSXaaim1Lk2igP7s1eCwEZqgkeyS5LslHklyd5FNJDk5ycZKfJNm/bbd1kjOSLE5yWZIjkswGTgWOSnJ5kqOSnJLk9CRfB85MclCSr7brmJPk35JcleTKJH+2kbEfn+TLSc5Ncn2St/U8px8l+SBwKbBbkkOSfC/JpUk+l2RO2/aZSb6b5IokP0iyzaiYD2yf2+Xt896mXf/V7fItep7TZUn+oCe2L7Sx/STJwo15rlIHBuKLQJLNJ9qnqj5UVWdu6u1Kg2IGfHaP+fmY5BVJfpzkQmB+z/zfSPLF9rP6iiTPaef/Xft3OD/Jp5OctDGxaT2qytsMvAF7AKuAvWkKvh8CZwABjgC+1Lb7P8Cx7ePtgB8DWwPHAx/oWd8p7Tq2bKcPAr7aPn4X8L6ettuPEc97gcvHuL1ljLbHA3cAOwJbAlcD89rntAZ4dttuJ+AiYOt2+m+Ak4HZwE3AM9v5jwE2HxXzV4D57eM57fI9gKvbeW8C/q19/FTgVmCLNrabgG3b6VuA3ab6/+1t5tza1+F1wEfa1/6ngIOBi4GfAPu37bZuc3oxcFmb17Pb1+ryNr+OanP3dODrwL+PyoM5wL8BVwFXAn+2kbEfD3yuza9vtvPe3MZ4JfD3PW1f3s67AvhEO+8U4KT28QXA+4Dvtn+H/dez3dHPcQ/g2zQ/GFwKPKdtd1C73rPbv/GngLTLbm7fU7YEzgX+fKpfC96G78b0/+z+tc9H4Dfb96Wd2/eoi9fGCHwGeH37eFbbd167jS2BbWje906a6v/NTL35y8nM9p9VdRVAkmuAb1RVJbmK5s0G4BDg8J5qewtg93Wsb1FVrRxj/sHA0Wsnquqe0Q2q6g0TjP38qrq7jf0LwHOBLwG3VNUlbZtnA3sBFyeB5g3me8BTgDuqanG77Z+26+ld/8XA/03yKeALVbV01PLnAu9v+1+X5Bbgye2yb1TVfe06rwWeANw2wecnrc+TgBcDJ9B8iX4JzWvycOB/Ai8C3krzZfuVSbYDfgD8B00xPK+qTgRIcgrwDOC5VbUyyUE92/k74L6q2rttu/3oQJK8F/iDMWI8q6reOcb83wP2qaoVSQ4B5gL703yRWZTkAODuNv75VXVXkh3W8XfYuqqe0/Y5A3j6Otox6jluBTy/qn6eZC7waZovFwD7AU8Dbqd5H5gPfKddNgc4CzizNnLPhLQRpvNn91ifjzsBF1TV8nb+Z/jV5+kf0vwoQFWtBu5L8lzgy2tjTvKVCcagCbAQmNke6nm8pmd6Db/634fmV8DrezsmedYY63twHdsJUOsLpI8vE6PXt3a6N4bQFAzHjNrWPhuKp6remeT/0QyhuCTJwcDPR617XXr/rqsxjzT5pvMXgfOrakVPjIfQ7LGA5ov2XOB3gLOr6q52Gyt+bS2NT7fLL0rymCTbVdW962jb+xwfBXwgyb40OfrknnY/qKqlAEkup/l7ri0EvgwsrKpPjfvZSpNvOn92r+vzcb3bGSMubSIeI6DzgNem/Tk8yX7t/PtpdsmNx9eBE9dOjPWrYlW9oar2HeM21hsJwPOT7JBkS5pfPy8eo80lwPwkT2q3u1WSJ9Ps8n9ckme287cZPW44yROr6qqqehewhGb4T6+LgJe2bZ9M8wXreqRNYyJfBNbm0u5V9aN1rG+jvgj0HE/Te3vLOLYV4B09MT6pqj46nu221vWDwIa2+wbgv2gKjnk0ewvXWl8hfzHwgrXvh9IAG9TP7rF8HzgoyY5JHkWzt3OtbwB/2W5/VpLH0BTmh6U5Vm8O8MIJbEsTZCGgt9P8enZlmgNl397O/xaw19oDjjawjv8NbN8e2HQFY/96MFHfAT5BM07w81W1ZHSDdjfj8cCnk1xJUxg8tap+QTM2+v1tPOfT/Fra6/U98a4EvjZq+QeBWe0vsJ8Bjq+qh5AGx3T4InAe8Mr86iD+xyd5LM2H/39PsmM7f11Dg45qlz+XZgjTfeN8XtvSDA9cA7yMZuzxeJxMM2zpg+NsL02VQf3s/jVVdQfNsQrfoxm+eGnP4r8G/qD9rP0h8LR2WO8imuOHvkDzY914c18TtPYgKWlgJDmenjHO0jBJsgfNwXxPb6c/1k6f3bus3Vv2PuA5NL+w31xVf9x+qT6P5kvCO4DfBh6oqn9s13cQzYF3f9x+QT+NZnz9apqDeb+wEbEfz6jcTfLXwKvbyQdoDnC8MclxNAcSrwYuq6rj2+MZHqiqf0xyAc0XhwNpDvh/ZVX9YB3b/WW/dnou8HngZzRfjF5bVXN6n3vb7gPAkqr6WJKbafYe3E1zPMLyqlrQ799CUv+SzKmqB9rjfS4CTqiqSzfUTxNnIaCBYyEgqS0EThprb6CkmS3Jv9OcDGQL4ONV9Y4pDmnGshCQJA0cCwFJ6p6FgCRpWkjyCpoxxb0urqq/mop4JGm6sxCQJEmShtCMOf/5oYceWueee+5UhyGp0ffpF81laaD0lcvmsTRQ1pnHM+b0oXfddddUhyBpEpjL0vRnHkvTw4wpBCRJkiSNn4WAJEmSNIQsBCRJkqQhZCEgSZIkDSELAUmSJGkIzZjTh0qSJA2zBQsWMDIywi677MLChQunOhxNAxYCkiRJM8DIyAjLli2b6jA0jTg0SJIkSRpCFgKSJEnSELIQkCRJkoaQhYAkSZI0hDo9WDjJocA/AbOAj1TVO0ctfyPwamAVsBx4ZVXd0i5bDVzVNr21qg7vMlZJkqRBMP/98/vqN/ve2WzGZtx27219rePi117c13Y1fXVWCCSZBZwGPB9YCixOsqiqru1pdhkwr6p+luQvgYXAUe2ylVW1b1fxSZIkScOsy6FB+wM3VNVNVfUL4CzgiN4GVfWtqvpZO3kJsGuH8UiSJElqdVkIPB64rWd6aTtvXV4FfK1neoskS5JckuRFY3VIckLbZsny5cs3PmJJU8JclqY/81iafrosBDLGvBqzYXIsMA94d8/s3atqHvAS4H1JnvhrK6s6varmVdW8nXfeeTJiljQFzGVp+jOPpemny0JgKbBbz/SuwO2jGyU5GHgrcHhVPbR2flXd3t7fBFwA7NdhrJIkSdJQ6bIQWAzMTbJnktnA0cCi3gZJ9gM+TFME3Nkzf/skj24f7wTMB3oPMpYkSVKP2qpYs/UaaqsxB2BIv6azswZV1aokJwLn0Zw+9IyquibJqcCSqlpEMxRoDvC5JPCr04T+NvDhJGtoipV3jjrbkCRJkno8PP/hqQ5B00yn1xGoqnOAc0bNO7nn8cHr6PddYO8uY5MkSZKGmVcWliRJkoZQp3sEJEnTw4IFCxgZGWGXXXZh4cKFUx2OJGkTsBCQJDEyMsKyZcumOgxJ0ibk0CBJkiRpCFkISJIkSUPIQkCSJEkaQhYCkiRJ0hCyEJAkSZKGkIWAJEmSNIQsBCRJkqQh5HUEJEmaIC/AJmkmsBCQJGmCvACbpJnAQkCSZpD575/fV7/Z985mMzbjtntv62sdF7/24r62K0maOh4jIEmSJA0hCwFJkiRpCFkISJIkSUPIQkCSJEkaQhYCkiRJ0hDqtBBIcmiS65PckOQtYyx/Y5Jrk1yZ5BtJntCz7LgkP2lvx3UZpyRJkjRsOisEkswCTgNeAOwFHJNkr1HNLgPmVdU+wNnAwrbvDsDbgGcB+wNvS7J9V7FKkiRJw6bL6wjsD9xQVTcBJDkLOAK4dm2DqvpWT/tLgGPbx38EnF9VK9q+5wOHAp/uMF5J0pD5wJu+0le/e+968Jf3/azjxPcc1td2JWkydTk06PHAbT3TS9t56/Iq4GsT6ZvkhCRLkixZvnz5RoYraaqYy9L0Zx5L00+XhUDGmFdjNkyOBeYB755I36o6varmVdW8nXfeue9AJU0tc3nq1VbFmq3XUFuN+TYtbZB5LE0/XQ4NWgrs1jO9K3D76EZJDgbeChxYVQ/19D1oVN8LOolSksTD8x+e6hAkSZtYl3sEFgNzk+yZZDZwNLCot0GS/YAPA4dX1Z09i84DDkmyfXuQ8CHtPEmSJEmToLM9AlW1KsmJNF/gZwFnVNU1SU4FllTVIpqhQHOAzyUBuLWqDq+qFUneTlNMAJy69sBhSZIkSRuvy6FBVNU5wDmj5p3c8/jg9fQ9Aziju+gkSZKk4dVpISBJkiQNogULFjAyMsIuu+zCwoULpzqcKWEhIEmSpKEzMjLCsmXLpjqMKdXlwcKSJEmSBpSFgCRJkjSEHBokSdIEbT37MY+4l6TpyEJAkqQJmv/EP53qECRpo1kISJIkadr6wJu+0le/e+968Jf3/azjxPcc1td2B4nHCEiSJElDyEJAkiRJGkIWApIkSdIQshCQJEmShpAHC0uSJGnoeBpgCwFJkiQNIU8D7NAgSZIkaShZCEiSJElDyEJAkiRJGkIWApIkSdIQ6rQQSHJokuuT3JDkLWMsPyDJpUlWJTly1LLVSS5vb4u6jFOSJEkaNp2dNSjJLOA04PnAUmBxkkVVdW1Ps1uB44GTxljFyqrat6v4JEmSpGHW5elD9wduqKqbAJKcBRwB/LIQqKqb22VrOoxDkiRJ0ihdDg16PHBbz/TSdt54bZFkSZJLkrxockOTJEmShluXewQyxryaQP/dq+r2JL8FfDPJVVV14yM2kJwAnACw++679x+ppCllLkvTn3ksTT/r3COQ5P4kPx3jdn+Sn45j3UuB3XqmdwVuH29gVXV7e38TcAGw3xhtTq+qeVU1b+eddx7vqiUNGHNZmv7MY2n6WecegaraZiPXvRiYm2RPYBlwNPCS8XRMsj3ws6p6KMlOwHxg4UbGI0mSJKk17mMEkjw2ye5rbxtqX1WrgBOB84AfAZ+tqmuSnJrk8Hadz0yyFHgx8OEk17TdfxtYkuQK4FvAO0edbUiSJEnSRtjgMQLtl/b3AI8D7gSeQPPF/mkb6ltV5wDnjJp3cs/jxTRDhkb3+y6w94bWL0mSJKk/49kj8Hbg2cCPq2pP4HnAxZ1GJUmSJKlT4ykEHq6qu4HNkmxWVd8CvNCXJEmSNI2N5/Sh9yaZA3wb+FSSO4FV3YYlSZIkqUvj2SNwEbAd8NfAucCNwGFdBiVJkiSpW+MpBEJz5p8LgDnAZ9qhQpIkSZKmqQ0WAlX191X1NOCvaM4cdGGS/+g8MkmSJEmdGfd1BGhOHToC3A08tptwJEmSJG0KGywEkvxlkguAbwA7AX9eVft0HZgkSZKk7oznrEFPAF5fVZd3HYwkSZKkTWODhUBVvWVTBCJJkiRp05nIMQKSJEmSZggLAUmSJGkIWQhIkiRJQ8hCQJIkSRpCFgKSJEnSELIQkCRJkoaQhYAkSZI0hCwEJEmSpCHUaSGQ5NAk1ye5IcmvXZgsyQFJLk2yKsmRo5Ydl+Qn7e24LuOUJEmShk1nhUCSWcBpwAuAvYBjkuw1qtmtwPHAv4/quwPwNuBZwP7A25Js31WskiRJ0rDpco/A/sANVXVTVf0COAs4ordBVd1cVVcCa0b1/SPg/KpaUVX3AOcDh3YYqyRJkjRUuiwEHg/c1jO9tJ03aX2TnJBkSZIly5cv7ztQSVPLXJamP/NYmn66LAQyxryazL5VdXpVzauqeTvvvPOEgpM0OMxlafozj6Xpp8tCYCmwW8/0rsDtm6CvJEmSpA3oshBYDMxNsmeS2cDRwKJx9j0POCTJ9u1Bwoe08yRJkiRNgs4KgapaBZxI8wX+R8Bnq+qaJKcmORwgyTOTLAVeDHw4yTVt3xXA22mKicXAqe08SZIkSZNg8y5XXlXnAOeMmndyz+PFNMN+xup7BnBGl/FJkiRJw8orC0uSJElDqNM9ApI0VRYsWMDIyAi77LILCxcunOpwJPXBPJa6ZSEgaUYaGRlh2bJlUx2GpI1gHkvdcmiQJEmSNITcIyBJkjQBDlnSTGEhIEmSOvWMN5/ZV79t7rqfWcCtd93f1zp++O6X97XdDXHIkmYKhwZJkiRJQ8hCQJIkSRpCDg2SNNBm2pACxxZLg+PWU/fuq9+qFTsAm7NqxS19rWP3k6/qa7vSZLMQkKRNyLHF0vitmb31I+4lTS4LAUmSNJAenHvIVIcgzWgeIyBJkiQNIfcISJIkTcBOW6wBVrX30vRlISBJkjQBJ+1z71SHIE0KCwFJkiR1xrOlDS4LAUkzUtdnG/G0g5I0Pp4tbXBZCEiakTzbiCRJ62chIEmSpA268IAD++q3cvNZkLBy6dK+1nHgRRf2tV1tWKenD01yaJLrk9yQ5C1jLH90ks+0y7+fZI92/h5JVia5vL19qMs4JUmSpGHT2R6BJLOA04DnA0uBxUkWVdW1Pc1eBdxTVU9KcjTwLuCodtmNVbVvV/FJkiRJw6zLPQL7AzdU1U1V9QvgLOCIUW2OAD7ePj4beF6SdBiTJEmSJLotBB4P3NYzvbSdN2abqloF3Afs2C7bM8llSS5M8vtjbSDJCUmWJFmyfPnyyY1e0iYzTLm80xZr+I0tvRCRZp5hymNNzHZV7FDFdlVTHYpG6fJg4bF+2R/9ClhXmzuA3avq7iTPAL6U5GlV9dNHNKw6HTgdYN68eb66pGlqmHLZCxFpphqmPNbEHLvaHz4GVZd7BJYCu/VM7wrcvq42STYHtgVWVNVDVXU3QFX9ELgReHKHsUqSJElDpctCYDEwN8meSWYDRwOLRrVZBBzXPj4S+GZVVZKd24ONSfJbwFzgpg5jlSRJkoZKZ0ODqmpVkhOB84BZwBlVdU2SU4ElVbUI+CjwiSQ3ACtoigWAA4BTk6wCVgOvqaoVXcUqSRpMCxYsYGRkhF122YWFCxdOdTiS1LlN+b7X6QXFquoc4JxR807uefxz4MVj9Ps88PkuY5MkDb6RkRGWLVs21WFI0iazKd/3Or2gmCRJkqTB1OkeAUmSJGkY/cOxR/bVb8Wd9zX3I3f0tY63fvLscbe1ENBGcfyupPG48IAD++q3cvNZkLBy6dK+1nHgRRf2tV1JGgYWAgJg/vvn99Vv9nWz2ezBzbjt3tv6XsfFr724r36SJEkzzRazNnvEfZcsBCRJkqQBsd+O22yybVkIaKPUVsUa1lBbeRFJSZKk6cRCQBvl4fkPT3UIkmaw7aoecS9JmjwWApKkgXXs6jVTHYIkzVgWAtIm5FmWJEnSoLAQkPrwgTd9pa9+1/3oRh586F7uvevBvtdx4nsO66ufJElSL68sLEmSJA0h9whIm9DWsx/ziHtJmkwOP5Q0ERYC0iY0/4l/OtUhSJrBRkZGWLZs2VSHIWmasBCQJGnA/MOxR/bVb8Wd9zX3I3f0tY63fvLsvrYraXqyEBhlUHerDmpckiRJmp5mbCHwjDef2Ve/ba75CbMe+im33nV/3+v44btfvs5lt566d1/rXHrtDvzXys1ZteKWvtex+8lX9dVPkjQ9bDFrs0fcS9L6zNhCQDPDhQccOGXbPvCiC6ds25LUj/123GaqQ5A0jVgIjLJm9taPuB8UO22xBljV3ktj63dc8WRwbLEkSdNLp4VAkkOBfwJmAR+pqneOWv5o4EzgGcDdwFFVdXO77G+BVwGrgddV1XldxrrWg3MP2RSbmbCT9rl3qkOQJEnSDNLZIMIks4DTgBcAewHHJNlrVLNXAfdU1ZOA9wLvavvuBRwNPA04FPhguz5JkiRJk6DLo4n2B26oqpuq6hfAWcARo9ocAXy8fXw28LwkaeefVVUPVdV/Aje065MkSZI0CVJV3aw4ORI4tKpe3U6/DHhWVZ3Y0+bqts3SdvpG4FnAKcAlVfXJdv5Hga9V1dmjtnECcEI7+RTg+kkKfyfgrkla12QyrokxromZzLjuqqpDx9vYXB4YxjUxwxDXuHPZPB4YxjUxwxDXOvO4y2MEMsa80VXHutqMpy9VdTpw+sRDW78kS6pq3mSvd2MZ18QY18RMZVzm8mAwrokxrkcyjweDcU3MsMfV5dCgpcBuPdO7Arevq02SzYFtgRXj7CtJkiSpT10WAouBuUn2TDKb5uDfRaPaLAKOax8fCXyzmrFKi4Cjkzw6yZ7AXOAHHcYqSZIkDZXOhgZV1aokJwLn0Zw+9IyquibJqcCSqloEfBT4RJIbaPYEHN32vSbJZ4FrgVXAX1XV6q5iHcOk79qcJMY1McY1MYMa18YY1OdkXBNjXBMzqHH1a1Cfj3FNjHFNzCaJq7ODhSVJkiQNri6HBkmSJEkaUBYCkiRJ0hAa2kIgyZ8kqSRPbaf3aK9rMLrds5N8P8nlSX6U5JSO4lndbuOKJJcmeU47/3FJzt5Q/64keWDU9BuS/DzJtj3zDkry1TH6/nGSy9rndG2Sv9gUMbfbfqC9H/P/2vG21/4vr07yuSRbbcrtb8hYf5MkpyQ5KckFSeatr+2gGaRcNo8n11Tmcbvdgc1l83j4PpPN4763P7B5DFOfy0NbCADHAN+hPUB5PT4OnFBV+wJPBz7bUTwrq2rfqvod4G+BdwBU1e1VdWRH2+zHMTRnhPqT9TVK8iiaA10Oa5/TfsAFnUc3GNb+L58O/AJ4zVQHNMMNUi6bxzOLubzpDFIew/TIZfN4fMzj9RjKQiDJHGA+8Co2/KbzWOAOgKpaXVXXdhwewGOAe+CR1V/7+NvtrxO9v1D8ZpKLeire3+8iqCRPBOYA/4vmDWh9tqE5K9XdAFX1UFVN1lUmp5NvA08CSPLG9v9zdZLXt/P2SHJdko8nuTLJ2YP2a8UgG/BcNo9nFnO5IwOexzCAuWwe9808HmUoCwHgRcC5VfVjYEWS311P2/cC1yf5YpK/SLJFRzFt2b5pXAd8BHj7GG3uBJ5fVb8LHAX8czv/JcB57S8kvwNc3lGMxwCfpkmkpyR57LoaVtUKmutB3JLk00lemmSoXm9pLpL3AuCqJM8AXgE8C3g28OdJ9mubPgU4var2AX4K/I+piHeaGrRcNo9nIHO5c4OWxzD4uWweT5B5PLaheyG0jgHOah+fxXqq6ao6FZgHfJ0muc/tKKa1u66eChwKnJkko9o8CvjXJFcBnwP2aucvBl6RZqzk3lV1f0cxHg2cVVVrgC8AL15f46p6NfA8movBnQSc0VFcg2bLJJcDS4Bbaa6X8Vzgi1X1YFU9QPP3W/sr0W1VdXH7+JNt2y6t65zBtY5lg3yO4UHLZfN4ZhnkXDaPh/sz2Twev0HOY5jiXO7sgmKDKsmOwB8CT09SNBc7K+CD6+pTVTcC/5LkX4HlSXasqru7irGqvpdkJ2DnUYveAPwXzS8MmwE/b9tflOQA4IU0F2h7d1WdOZkxJdmH5grP57fvhbOBm4DTNvBcrqKpvj8B/Cdw/GTGNaBWtr8E/dIYHyC9Rid11x/YdwPbj5q3A83/Z/SyHYC7Oo6nL4Oey+bxjDDIuWweD+lnsnk8YYOcxzDFuTyMewSOBM6sqidU1R5VtRvNH3vXsRoneWHPC2YusBq4t8sA05w1YRbteL4e2wJ3tL8AvKxtQ5InAHdW1b/SVLrr263ar2OAU9q/2R5V9Tjg8e22x3oOc5Ic1DNrX+CWDuKaLi4CXpRkqyRb0xzc9e122e5Jfq99vPaAuc60v37ckeR5AEl2oPnF6zs0B5Ad2/OaPw74VpfxbISBzmXzeMYaiFw2j4Hh/Uw2jzfeQOQxTH0uD90eAZp/6jtHzfs88D9pxtkt7Zn/BuDPgPcm+RmwCnhpVa3uIK61u64AAhxXVatHFa0fBD6f5MU0L4QH2/kHAW9O8jDwAPDyDuI7mmZsXa8vtvO/Dzxv1N/uGGBBkg8DK9tYj+8grmmhqi5N8jGa3bIAH6mqy5LsAfwIOK79W/0E+JdNENLLgdOSvKed/vuqujHJ6cBTgSvaX+eW0JwxYxANYi6bxzPcgOWyeTycn8nm8UYasDyGKczlVA3ysEFpZmvfdL7antZM0jRlLkvT3zDm8TAODZIkSZKGnnsEJEmSpCHkHgFJkiRpCFkISJIkSUPIQkCSJEkaQhYCmjRJbm4vujIZ63pNkpe3j49P8rgutiPpkcxjaWYwlzUew3gdAQ24JJtX1Yd6Zh0PXA3cPjURSZoo81iaGczlmc1CQH1J8iVgN2AL4J+q6vRRy/8OeClwG83lsH9YVf+YZF/gQ8BWwI3AK6vqniQXAN8F5gOLkmxDcyGWm4F5wKeSrATWXu3vtUkOAx4FvLiqrktyCrAn8JvAk4E3As+mufDKMuCwqnq4gz+HNC2Zx9LMYC6rXw4NUr9eWVXPoHlDeF2SHdcuSDKP5uqP+wF/2rZZ60zgb6pqH+Aq4G09y7arqgOrau2V9aiqs2mupPfSqtq3qla2i+6qqt+lueLfST3reCLwQuAI4JPAt6pqb5qrKb5wEp63NJOYx9LMYC6rLxYC6tfrklwBXELzK8TcnmXPBb5cVSur6n7gKwBJtqV5Y7mwbfdx4ICefp+ZwPa/0N7/ENijZ/7X2l8YrgJmAee2868a1U6SeSzNFOay+uLQIE1YkoOAg4Hfq6qftbsQt+ht0ueqH5xA24fa+9U88nX8EEBVrUnycP3qinlr8PUu/ZJ5LM0M5rI2hnsE1I9tgXvaN5yn0oz56/Ud4LAkWySZQ7v7r6ruA+5J8vttu5Nl7gwAAAC/SURBVJcBF7Jh9wPbTE7oklrmsTQzmMvqm9WY+nEu8JokVwLX0+yK/KWqWpxkEXAFcAvNeML72sXHAR9KshVwE/CKcWzvY22f3gOTJG0c81iaGcxl9S2/2ksjTZ4kc6rqgfbN5SLghKq6dKrjkjR+5rE0M5jLWhf3CKgrpyfZi2ac4sd9w5GmJfNYmhnMZY3JPQKSJEnSEPJgYUmSJGkIWQhIkiRJQ8hCQJIkSRpCFgKSJEnSELIQkCRJkobQ/wdFji68IQNFDAAAAABJRU5ErkJggg==\n",
       "text/plain": [
        "<Figure size 777.6x216 with 3 Axes>"
       ]
@@ -713,10 +713,10 @@
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.01403,
-     "end_time": "2020-03-22T18:56:28.876408",
+     "duration": 0.015998,
+     "end_time": "2020-03-23T18:53:46.164633",
      "exception": false,
-     "start_time": "2020-03-22T18:56:28.862378",
+     "start_time": "2020-03-23T18:53:46.148635",
      "status": "completed"
     },
     "tags": []
@@ -729,10 +729,10 @@
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.01497,
-     "end_time": "2020-03-22T18:56:28.905378",
+     "duration": 0.015999,
+     "end_time": "2020-03-23T18:53:46.197636",
      "exception": false,
-     "start_time": "2020-03-22T18:56:28.890408",
+     "start_time": "2020-03-23T18:53:46.181637",
      "status": "completed"
     },
     "tags": []
@@ -745,10 +745,10 @@
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.014001,
-     "end_time": "2020-03-22T18:56:28.933410",
+     "duration": 0.016009,
+     "end_time": "2020-03-23T18:53:46.229666",
      "exception": false,
-     "start_time": "2020-03-22T18:56:28.919409",
+     "start_time": "2020-03-23T18:53:46.213657",
      "status": "completed"
     },
     "tags": []
@@ -761,10 +761,10 @@
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.013976,
-     "end_time": "2020-03-22T18:56:28.961376",
+     "duration": 0.016001,
+     "end_time": "2020-03-23T18:53:46.261665",
      "exception": false,
-     "start_time": "2020-03-22T18:56:28.947400",
+     "start_time": "2020-03-23T18:53:46.245664",
      "status": "completed"
     },
     "tags": []
@@ -779,10 +779,10 @@
    "execution_count": 15,
    "metadata": {
     "papermill": {
-     "duration": 0.076031,
-     "end_time": "2020-03-22T18:56:29.051409",
+     "duration": 0.086997,
+     "end_time": "2020-03-23T18:53:46.365633",
      "exception": false,
-     "start_time": "2020-03-22T18:56:28.975378",
+     "start_time": "2020-03-23T18:53:46.278636",
      "status": "completed"
     },
     "tags": []
@@ -792,7 +792,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Statistics=1582.163, p=0.000\n"
+      "Statistics=1529.584, p=0.000\n"
      ]
     }
    ],
@@ -811,10 +811,10 @@
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.014001,
-     "end_time": "2020-03-22T18:56:29.079408",
+     "duration": 0.017,
+     "end_time": "2020-03-23T18:53:46.404636",
      "exception": false,
-     "start_time": "2020-03-22T18:56:29.065407",
+     "start_time": "2020-03-23T18:53:46.387636",
      "status": "completed"
     },
     "tags": []
@@ -827,10 +827,10 @@
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.014029,
-     "end_time": "2020-03-22T18:56:29.108408",
+     "duration": 0.017999,
+     "end_time": "2020-03-23T18:53:46.439636",
      "exception": false,
-     "start_time": "2020-03-22T18:56:29.094379",
+     "start_time": "2020-03-23T18:53:46.421637",
      "status": "completed"
     },
     "tags": []
@@ -843,10 +843,10 @@
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.014,
-     "end_time": "2020-03-22T18:56:29.137379",
+     "duration": 0.017,
+     "end_time": "2020-03-23T18:53:46.473637",
      "exception": false,
-     "start_time": "2020-03-22T18:56:29.123379",
+     "start_time": "2020-03-23T18:53:46.456637",
      "status": "completed"
     },
     "tags": []
@@ -862,10 +862,10 @@
    "execution_count": 16,
    "metadata": {
     "papermill": {
-     "duration": 0.033,
-     "end_time": "2020-03-22T18:56:29.184379",
+     "duration": 0.03,
+     "end_time": "2020-03-23T18:53:46.520637",
      "exception": false,
-     "start_time": "2020-03-22T18:56:29.151379",
+     "start_time": "2020-03-23T18:53:46.490637",
      "status": "completed"
     },
     "tags": []
@@ -875,12 +875,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "('ALS', 'Bias'), Statistics=38626.500, p-value=0.827, Metric is the same (fail to reject H0)\n",
-      "('ALS', 'IALS'), Statistics=5702.000, p-value=0.000, Metric is different (reject H0)\n",
-      "('ALS', 'II'), Statistics=17987.500, p-value=0.000, Metric is different (reject H0)\n",
-      "('Bias', 'IALS'), Statistics=9429.000, p-value=0.000, Metric is different (reject H0)\n",
-      "('Bias', 'II'), Statistics=20550.500, p-value=0.000, Metric is different (reject H0)\n",
-      "('IALS', 'II'), Statistics=5407.000, p-value=0.000, Metric is different (reject H0)\n"
+      "('ALS', 'Bias'), Statistics=32241.500, p-value=0.386, Metric is the same (fail to reject H0)\n",
+      "('ALS', 'IALS'), Statistics=6923.500, p-value=0.000, Metric is different (reject H0)\n",
+      "('ALS', 'II'), Statistics=15536.500, p-value=0.000, Metric is different (reject H0)\n",
+      "('Bias', 'IALS'), Statistics=8869.000, p-value=0.000, Metric is different (reject H0)\n",
+      "('Bias', 'II'), Statistics=26113.000, p-value=0.000, Metric is different (reject H0)\n",
+      "('IALS', 'II'), Statistics=7250.500, p-value=0.000, Metric is different (reject H0)\n"
      ]
     }
    ],
@@ -907,10 +907,10 @@
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.020981,
-     "end_time": "2020-03-22T18:56:29.223377",
+     "duration": 0.017,
+     "end_time": "2020-03-23T18:53:46.554637",
      "exception": false,
-     "start_time": "2020-03-22T18:56:29.202396",
+     "start_time": "2020-03-23T18:53:46.537637",
      "status": "completed"
     },
     "tags": []
@@ -923,10 +923,10 @@
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.019001,
-     "end_time": "2020-03-22T18:56:29.263380",
+     "duration": 0.017,
+     "end_time": "2020-03-23T18:53:46.588636",
      "exception": false,
-     "start_time": "2020-03-22T18:56:29.244379",
+     "start_time": "2020-03-23T18:53:46.571636",
      "status": "completed"
     },
     "tags": []
@@ -939,10 +939,10 @@
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.020998,
-     "end_time": "2020-03-22T18:56:29.306377",
+     "duration": 0.017,
+     "end_time": "2020-03-23T18:53:46.622636",
      "exception": false,
-     "start_time": "2020-03-22T18:56:29.285379",
+     "start_time": "2020-03-23T18:53:46.605636",
      "status": "completed"
     },
     "tags": []
@@ -957,10 +957,10 @@
    "execution_count": 17,
    "metadata": {
     "papermill": {
-     "duration": 0.092028,
-     "end_time": "2020-03-22T18:56:29.419408",
+     "duration": 0.086002,
+     "end_time": "2020-03-23T18:53:46.725638",
      "exception": false,
-     "start_time": "2020-03-22T18:56:29.327380",
+     "start_time": "2020-03-23T18:53:46.639636",
      "status": "completed"
     },
     "tags": []
@@ -970,7 +970,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Statistics=1111.864, p=0.000\n"
+      "Statistics=1086.095, p=0.000\n"
      ]
     }
    ],
@@ -989,10 +989,10 @@
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.017981,
-     "end_time": "2020-03-22T18:56:29.457377",
+     "duration": 0.015998,
+     "end_time": "2020-03-23T18:53:46.759635",
      "exception": false,
-     "start_time": "2020-03-22T18:56:29.439396",
+     "start_time": "2020-03-23T18:53:46.743637",
      "status": "completed"
     },
     "tags": []
@@ -1005,10 +1005,10 @@
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.022017,
-     "end_time": "2020-03-22T18:56:29.501396",
+     "duration": 0.017001,
+     "end_time": "2020-03-23T18:53:46.792637",
      "exception": false,
-     "start_time": "2020-03-22T18:56:29.479379",
+     "start_time": "2020-03-23T18:53:46.775636",
      "status": "completed"
     },
     "tags": []
@@ -1021,10 +1021,10 @@
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.020995,
-     "end_time": "2020-03-22T18:56:29.542376",
+     "duration": 0.017,
+     "end_time": "2020-03-23T18:53:46.826636",
      "exception": false,
-     "start_time": "2020-03-22T18:56:29.521381",
+     "start_time": "2020-03-23T18:53:46.809636",
      "status": "completed"
     },
     "tags": []
@@ -1040,10 +1040,10 @@
    "execution_count": 18,
    "metadata": {
     "papermill": {
-     "duration": 0.034969,
-     "end_time": "2020-03-22T18:56:29.598379",
+     "duration": 0.031002,
+     "end_time": "2020-03-23T18:53:46.875636",
      "exception": false,
-     "start_time": "2020-03-22T18:56:29.563410",
+     "start_time": "2020-03-23T18:53:46.844634",
      "status": "completed"
     },
     "tags": []
@@ -1053,12 +1053,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "('ALS', 'Bias'), Statistics=112343.000, p-value=0.733, Metric is the same (fail to reject H0)\n",
-      "('ALS', 'IALS'), Statistics=31738.000, p-value=0.000, Metric is different (reject H0)\n",
-      "('ALS', 'II'), Statistics=56653.500, p-value=0.000, Metric is different (reject H0)\n",
-      "('Bias', 'IALS'), Statistics=33190.000, p-value=0.000, Metric is different (reject H0)\n",
-      "('Bias', 'II'), Statistics=59601.000, p-value=0.000, Metric is different (reject H0)\n",
-      "('IALS', 'II'), Statistics=15546.000, p-value=0.000, Metric is different (reject H0)\n"
+      "('ALS', 'Bias'), Statistics=104382.000, p-value=0.141, Metric is the same (fail to reject H0)\n",
+      "('ALS', 'IALS'), Statistics=35776.000, p-value=0.000, Metric is different (reject H0)\n",
+      "('ALS', 'II'), Statistics=53502.000, p-value=0.000, Metric is different (reject H0)\n",
+      "('Bias', 'IALS'), Statistics=33026.000, p-value=0.000, Metric is different (reject H0)\n",
+      "('Bias', 'II'), Statistics=66442.000, p-value=0.000, Metric is different (reject H0)\n",
+      "('IALS', 'II'), Statistics=18490.000, p-value=0.000, Metric is different (reject H0)\n"
      ]
     }
    ],
@@ -1085,10 +1085,10 @@
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.017024,
-     "end_time": "2020-03-22T18:56:29.634403",
+     "duration": 0.017001,
+     "end_time": "2020-03-23T18:53:46.910635",
      "exception": false,
-     "start_time": "2020-03-22T18:56:29.617379",
+     "start_time": "2020-03-23T18:53:46.893634",
      "status": "completed"
     },
     "tags": []
@@ -1101,10 +1101,10 @@
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.015971,
-     "end_time": "2020-03-22T18:56:29.665379",
+     "duration": 0.016996,
+     "end_time": "2020-03-23T18:53:46.944663",
      "exception": false,
-     "start_time": "2020-03-22T18:56:29.649408",
+     "start_time": "2020-03-23T18:53:46.927667",
      "status": "completed"
     },
     "tags": []
@@ -1117,10 +1117,10 @@
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.015,
-     "end_time": "2020-03-22T18:56:29.695409",
+     "duration": 0.017,
+     "end_time": "2020-03-23T18:53:46.978663",
      "exception": false,
-     "start_time": "2020-03-22T18:56:29.680409",
+     "start_time": "2020-03-23T18:53:46.961663",
      "status": "completed"
     },
     "tags": []
@@ -1135,10 +1135,10 @@
    "execution_count": 19,
    "metadata": {
     "papermill": {
-     "duration": 0.078999,
-     "end_time": "2020-03-22T18:56:29.789409",
+     "duration": 0.083989,
+     "end_time": "2020-03-23T18:53:47.079664",
      "exception": false,
-     "start_time": "2020-03-22T18:56:29.710410",
+     "start_time": "2020-03-23T18:53:46.995675",
      "status": "completed"
     },
     "tags": []
@@ -1148,7 +1148,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Statistics=739.830, p=0.000\n"
+      "Statistics=832.931, p=0.000\n"
      ]
     }
    ],
@@ -1167,10 +1167,10 @@
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.014998,
-     "end_time": "2020-03-22T18:56:29.819407",
+     "duration": 0.01703,
+     "end_time": "2020-03-23T18:53:47.114664",
      "exception": false,
-     "start_time": "2020-03-22T18:56:29.804409",
+     "start_time": "2020-03-23T18:53:47.097634",
      "status": "completed"
     },
     "tags": []
@@ -1183,10 +1183,10 @@
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.014993,
-     "end_time": "2020-03-22T18:56:29.849408",
+     "duration": 0.016998,
+     "end_time": "2020-03-23T18:53:47.149634",
      "exception": false,
-     "start_time": "2020-03-22T18:56:29.834415",
+     "start_time": "2020-03-23T18:53:47.132636",
      "status": "completed"
     },
     "tags": []
@@ -1199,10 +1199,10 @@
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.014971,
-     "end_time": "2020-03-22T18:56:29.879379",
+     "duration": 0.017999,
+     "end_time": "2020-03-23T18:53:47.184635",
      "exception": false,
-     "start_time": "2020-03-22T18:56:29.864408",
+     "start_time": "2020-03-23T18:53:47.166636",
      "status": "completed"
     },
     "tags": []
@@ -1218,10 +1218,10 @@
    "execution_count": 20,
    "metadata": {
     "papermill": {
-     "duration": 0.027007,
-     "end_time": "2020-03-22T18:56:29.920416",
+     "duration": 0.033,
+     "end_time": "2020-03-23T18:53:47.234635",
      "exception": false,
-     "start_time": "2020-03-22T18:56:29.893409",
+     "start_time": "2020-03-23T18:53:47.201635",
      "status": "completed"
     },
     "tags": []
@@ -1231,12 +1231,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "('ALS', 'Bias'), Statistics=98533.500, p-value=0.027, Metric is the same (fail to reject H0)\n",
-      "('ALS', 'IALS'), Statistics=74841.500, p-value=0.000, Metric is different (reject H0)\n",
-      "('ALS', 'II'), Statistics=49330.000, p-value=0.000, Metric is different (reject H0)\n",
-      "('Bias', 'IALS'), Statistics=72225.000, p-value=0.000, Metric is different (reject H0)\n",
-      "('Bias', 'II'), Statistics=52734.000, p-value=0.000, Metric is different (reject H0)\n",
-      "('IALS', 'II'), Statistics=44102.000, p-value=0.000, Metric is different (reject H0)\n"
+      "('ALS', 'Bias'), Statistics=106155.500, p-value=0.899, Metric is the same (fail to reject H0)\n",
+      "('ALS', 'IALS'), Statistics=76216.000, p-value=0.000, Metric is different (reject H0)\n",
+      "('ALS', 'II'), Statistics=49108.000, p-value=0.000, Metric is different (reject H0)\n",
+      "('Bias', 'IALS'), Statistics=72196.500, p-value=0.000, Metric is different (reject H0)\n",
+      "('Bias', 'II'), Statistics=54424.000, p-value=0.000, Metric is different (reject H0)\n",
+      "('IALS', 'II'), Statistics=41157.000, p-value=0.000, Metric is different (reject H0)\n"
      ]
     }
    ],
@@ -1263,10 +1263,10 @@
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.015008,
-     "end_time": "2020-03-22T18:56:29.953402",
+     "duration": 0.017,
+     "end_time": "2020-03-23T18:53:47.269635",
      "exception": false,
-     "start_time": "2020-03-22T18:56:29.938394",
+     "start_time": "2020-03-23T18:53:47.252635",
      "status": "completed"
     },
     "tags": []
@@ -1282,10 +1282,10 @@
    "execution_count": 21,
    "metadata": {
     "papermill": {
-     "duration": 2.450501,
-     "end_time": "2020-03-22T18:56:32.419909",
+     "duration": 2.73699,
+     "end_time": "2020-03-23T18:53:50.024626",
      "exception": false,
-     "start_time": "2020-03-22T18:56:29.969408",
+     "start_time": "2020-03-23T18:53:47.287636",
      "status": "completed"
     },
     "tags": []
@@ -1301,10 +1301,10 @@
    "execution_count": 22,
    "metadata": {
     "papermill": {
-     "duration": 0.264046,
-     "end_time": "2020-03-22T18:56:32.699986",
+     "duration": 0.373,
+     "end_time": "2020-03-23T18:53:50.413626",
      "exception": false,
-     "start_time": "2020-03-22T18:56:32.435940",
+     "start_time": "2020-03-23T18:53:50.040626",
      "status": "completed"
     },
     "tags": []
@@ -1313,7 +1313,7 @@
     {
      "data": {
       "text/plain": [
-       "<seaborn.axisgrid.FacetGrid at 0x1dacbf08e08>"
+       "<seaborn.axisgrid.FacetGrid at 0x27f2897c348>"
       ]
      },
      "execution_count": 22,
@@ -1322,7 +1322,7 @@
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAWAAAAFgCAYAAACFYaNMAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjMsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+AADFEAAAVUElEQVR4nO3dfbRddX3n8ffHJIgWhFHSFQRiGJvRZRUBs1CHqTJS2/jUTBU6yVieWldql9TqiEx1tT6w1jyU2rpqUTNxZAmOS+gAtdEiDDNVkE6lBpoQIMUVtZYAKQlPggYk8J0/zo4eLie5BO6+v3Pvfb/Wuuvsh9/Z+3vuzf3cX35n799JVSFJmn7PaF2AJM1VBrAkNWIAS1IjBrAkNWIAS1Ij81sXsK+WL19eV1xxResyJGlfZNTGGdcD3rFjR+sSJGlKzLgAlqTZwgCWpEYMYElqxACWpEYMYElqxACWpEYMYElqxACWpEZ6C+Ak+yf5uyQbk9yc5KMj2jwzycVJtiS5LsmSvuqRpHHTZw/4YeB1VfVy4GhgeZJXTWjzm8C9VfVzwMeBP+yxHkkaK70FcA082K0u6L4mfvzGCuCCbvkS4MQkI++ZlqTZptcx4CTzkmwA7gKuqqrrJjQ5DLgNoKp2AfcDz+uzJkkaF73OhlZVjwJHJzkY+IskL62qm4aajOrtPuFD6pKsBlYDLF68uJdaNbedffbZbNu2jUWLFnHuuee2LkdzxLRcBVFV9wFfB5ZP2LUVOAIgyXzgIOCeEc9fW1XLqmrZwoULe65Wc9G2bdu4/fbb2bZtW+tSNIf0eRXEwq7nS5JnAb8I/MOEZuuA07rlk4C/Lj+mWdIc0ecQxKHABUnmMQj6P6+qryQ5B1hfVeuAzwKfT7KFQc93ZY/1SNJY6S2Aq+pG4JgR2z80tPwQcHJfNUjSOJtxH0mkuev4Pzu+t2Pvd99+PINncNt9t/V2nr/5nb/p5biaubwVWZIaMYAlqREDWJIacQxYAurZxWM8Rj3bqyA1fQxgCXjk+Edal6A5yCEISWrEAJakRgxgSWrEAJakRgxgSWrEAJakRgxgSWrEAJakRgxgSWrEAJakRgxgSWrEAJakRgxgSWrEAJakRgxgSWrEAJakRgxgSWrEAJakRgxgSWrEAJakRgxgSWrEAJakRgxgSWrEAJakRgxgSWrEAJakRgxgSWrEAJakRgxgSWrEAJakRgxgSWrEAJakRgxgSWrEAJakRnoL4CRHJPlaks1Jbk7yuyPanJDk/iQbuq8P9VWPJI2b+T0eexfwvqq6IcmBwPVJrqqqWya0+0ZVvbnHOiRpLPXWA66qO6vqhm75AWAzcFhf55OkmWZaxoCTLAGOAa4bsfvVSTYm+WqSn5+OeiRpHPQ5BAFAkgOAS4H3VNUPJuy+AXhBVT2Y5I3Al4ClI46xGlgNsHjx4p4rlqTp0WsPOMkCBuH7haq6bOL+qvpBVT3YLV8OLEhyyIh2a6tqWVUtW7hwYZ8lS9K06fMqiACfBTZX1Z/soc2irh1JjuvqubuvmiRpnPQ5BHE8cAqwKcmGbtsHgcUAVbUGOAn47SS7gJ3AyqqqHmuSpLHRWwBX1bVAJmlzHnBeXzVI0jjzTjhJasQAlqRGDGBJasQAlqRGDGBJasQAlqRGDGBJasQAlqRGDGBJasQAlqRGDGBJasQAlqRGDGBJasQAlqRGDGBJasQAlqRGDGBJasQAlqRGDGBJasQAlqRGDGBJasQAlqRGDGBJasQAlqRGDGBJasQAlqRGDGBJasQAlqRGDGBJasQAlqRGDGBJasQAlqRGDGBJasQAlqRGDGBJasQAlqRGDGBJasQAlqRGDGBJasQAlqRGDGBJaqS3AE5yRJKvJdmc5OYkvzuiTZJ8IsmWJDcmObaveiRp3Mzv8di7gPdV1Q1JDgSuT3JVVd0y1OYNwNLu65XAp7tHSZr1eusBV9WdVXVDt/wAsBk4bEKzFcCFNfBN4OAkh/ZVkySNk2kZA06yBDgGuG7CrsOA24bWt/LEkCbJ6iTrk6zfvn17X2VK0rTqPYCTHABcCrynqn4wcfeIp9QTNlStraplVbVs4cKFfZQpSdOu1wBOsoBB+H6hqi4b0WQrcMTQ+uHAHX3WJEnjos+rIAJ8FthcVX+yh2brgFO7qyFeBdxfVXf2VZMkjZM+r4I4HjgF2JRkQ7ftg8BigKpaA1wOvBHYAvwIOKPHeiRprPQWwFV1LaPHeIfbFPCuvmqQpHHmnXCS1IgBLEmNGMCS1IgBLEmNGMCS1IgBLEmNGMCS1IgBLEmNGMCS1IgBLEmNGMCS1IgBLEmNGMCS1IgBLEmNGMCS1IgBLEmNGMCS1IgBLEmNGMCS1IgBLEmNGMCS1IgBLEmNGMCS1IgBLEmNGMCS1MheAzjJ64aWj5yw7619FSVJc8FkPeCPDS1fOmHf709xLZI0p0wWwNnD8qh1SdI+mCyAaw/Lo9YlSftg/iT7/2WSdQx6u7uX6daP3PPTJEmTmSyAVwwtf2zCvonrkqR9sNcArqqrh9eTLABeCtxeVXf1WZgkzXaTXYa2JsnPd8sHARuBC4G/T7JqGuqTpFlrsjfhfqGqbu6WzwC+XVUvA14BnN1rZZI0y00WwD8eWn498CWAqtrWW0WSNEdMFsD3JXlzkmOA44ErAJLMB57Vd3GSNJtNdhXEbwGfABYB7xnq+Z4I/FWfhUnSbDfZVRDfBpaP2H4lcGVfRUnSXLDXAE7yib3tr6p3T205kjR3TDYE8U7gJuDPgTtw/gdJmjKTBfChwMnAvwd2ARcDl1bVvZMdOMn5wJuBu6rqpSP2nwD8JfC9btNlVXXOky9dkma2vV4FUVV3V9Waqvq3wOnAwcDNSU55Esf+HCPGjyf4RlUd3X0ZvpLmlMl6wAAkORZYxeBa4K8C10/2nKq6JsmSp1OcJM1mk70J91EGwwibgYuAD1TVrik8/6uTbGQwvnzW0F13E+tYDawGWLx48RSeXpLamawH/AfAd4GXd1//JQkM3oyrqjrqaZz7BuAFVfVgkjcyuMtu6aiGVbUWWAuwbNky5yGWNCtMFsC9zflbVT8YWr48yaeSHFJVO/o6pySNk8luxPj+qO1J5gErgZH7n4wki4B/rqpKchyDNwTvfqrHk6SZZrIx4OcA7wIOA9YBVwFnAmcBG4Av7OW5XwROAA5JshX4MLAAoKrWACcBv51kF7ATWFlVDi9ImjMmG4L4PHAv8LfAO4D3A/sBK6pqw96eWFV7nS+4qs4DznvypUrS7DLpZ8J18/+S5H8AO4DFVfVA75VJ0iw32XSUj+xeqKpHge8ZvpI0NSbrAb88ye6rFQI8q1vffRnac3qtTpJmscmugpg3XYVI0lwz2RCEJKknBrAkNWIAS1IjBrAkNWIAS1IjBrAkNWIAS1IjBrAkNWIAS1IjBrAkNWIAS1IjBrAkNWIAS1IjBrAkNWIAS1IjBrAkNWIAS1IjBrAkNWIAS1IjBrAkNWIAS1IjBrAkNWIAS1IjBrAkNWIAS1IjBrAkNWIAS1IjBrAkNWIAS1IjBrAkNWIAS1IjBrAkNWIAS1IjBrAkNWIAS1IjBrAkNdJbACc5P8ldSW7aw/4k+USSLUluTHJsX7VI0jjqswf8OWD5Xva/AVjafa0GPt1jLZI0dnoL4Kq6BrhnL01WABfWwDeBg5Mc2lc9kjRuWo4BHwbcNrS+tdv2BElWJ1mfZP327dunpThJ6lvLAM6IbTWqYVWtraplVbVs4cKFPZclSdOjZQBvBY4YWj8cuKNRLZI07eY3PPc64MwkFwGvBO6vqjsb1qMhZ599Ntu2bWPRokWce+65rcuRZqXeAjjJF4ETgEOSbAU+DCwAqKo1wOXAG4EtwI+AM/qqRftu27Zt3H777a3LkKbEuHYoegvgqlo1yf4C3tXX+SVpt3HtULQcgpgxxvWv5z+d87Lejr3rnucC89l1z/d7O8/iD23q5bjSTGEAPwnj+tdTeqrGsVNx3vu+3Nux79vxw5889nmeM//4LfvU3gCW5iA7FeNh1gTwK95/YW/HPnDHA8wD/mnHA72d5/o/OrWX40oaX7MmgDW1Dtn/MWBX96gWrn7Na3s79s758yBh59atvZ3ntddc3ctxn4qf2e85j3scFwawRjrrqPtalyBNmeNf+NbWJYxkAD8Jj+33M497lKSpYAA/CT9c+kutS5Cm1MFVj3tUGwawNAf9+qOO7Y8DP5JIkhoxgCWpEQNYkhoxgCWpEQNYkhoxgCWpEQNYkhoxgCWpEQNYkhoxgCWpEQNYkhoxgCWpEQNYkhoxgCWpEQNYkhoxgCWpEQNYkhoxgCWpEQNYkhoxgCWpEQNYkhoxgCWpEQNYkhoxgCWpEQNYkhoxgCWpEQNYkhoxgCWpEQNYkhoxgCWpEQNYkhrpNYCTLE9ya5ItSX5vxP7Tk2xPsqH7ekef9UjSOJnf14GTzAM+Cbwe2Ap8K8m6qrplQtOLq+rMvuqQpHHVZw/4OGBLVX23qn4MXASs6PF8kjSj9BnAhwG3Da1v7bZN9LYkNya5JMkRow6UZHWS9UnWb9++vY9aJWna9RnAGbGtJqx/GVhSVUcB/we4YNSBqmptVS2rqmULFy6c4jIlqY0+A3grMNyjPRy4Y7hBVd1dVQ93q58BXtFjPZI0VvoM4G8BS5McmWQ/YCWwbrhBkkOHVn8F2NxjPZI0Vnq7CqKqdiU5E7gSmAecX1U3JzkHWF9V64B3J/kVYBdwD3B6X/VI0rjpLYABqupy4PIJ2z40tPwB4AN91iBJ48o74SSpEQNYkhoxgCWpEQNYkhoxgCWpEQNYkhoxgCWpEQNYkhoxgCWpEQNYkhoxgCWpEQNYkhoxgCWpEQNYkhoxgCWpEQNYkhoxgCWpEQNYkhoxgCWpEQNYkhoxgCWpEQNYkhoxgCWpEQNYkhoxgCWpEQNYkhoxgCWpEQNYkhoxgCWpEQNYkhoxgCWpEQNYkhoxgCWpEQNYkhoxgCWpEQNYkhoxgCWpEQNYkhoxgCWpEQNYkhrpNYCTLE9ya5ItSX5vxP5nJrm4239dkiV91iNJ46S3AE4yD/gk8AbgJcCqJC+Z0Ow3gXur6ueAjwN/2Fc9kjRu+uwBHwdsqarvVtWPgYuAFRParAAu6JYvAU5Mkh5rkqSxkarq58DJScDyqnpHt34K8MqqOnOozU1dm63d+ne6NjsmHGs1sLpbfRFway9F790hwI5JW80uc+01+3pnt5avd0dVLZ+4cX6PJxzVk52Y9k+mDVW1Flg7FUU9VUnWV9WyljVMt7n2mn29s9s4vt4+hyC2AkcMrR8O3LGnNknmAwcB9/RYkySNjT4D+FvA0iRHJtkPWAmsm9BmHXBat3wS8NfV15iIJI2Z3oYgqmpXkjOBK4F5wPlVdXOSc4D1VbUO+Czw+SRbGPR8V/ZVzxRoOgTSyFx7zb7e2W3sXm9vb8JJkvbOO+EkqREDWJIaMYCHJPnVJJXkxd36ku5a5YntXtXdOr0hyeYkH5n2Yp+GJI92tW9MckOSf91tf36SS1rXN9WSPDhh/b1JHkpy0NC2E5J8ZcRz35zk77vv1S1Jfms6au7T7u/Hnv59z3SjXleSjyQ5K8nXkyzbW9vp1Od1wDPRKuBaBm8GfmQv7S4Afq2qNna3XL9oGmqbSjur6miAJL8M/FfgtVV1B4OrUWa7VQyu0vlV4HN7apRkAYM3bo6rqq1JngksmY4CNTfYA+4kOQA4nsH8FJNdjfGzwJ0AVfVoVd3Sc3l9eg5wLzy+N9Atf6PrIQ/3kg9Nck3Xg74pyS80rH2fJXkhcADw+wyCeG8OZNBJuRugqh6uqhZ3YWqWsgf8U/8OuKKqvp3kniTHsuebQj4O3Jrk68AVwAVV9dA01TkVnpVkA7A/cCjwuhFt7gJeX1UPJVkKfBFYBvwH4Mqq+s9d7//Z01X0FFnF4LV8A3hRkp+tqrtGNayqe5KsA76f5P8CXwG+WFWPTV+5ms3sAf/UKgYTBtE97rF3VFXnMAij/80gkK7ovbqptbOqjq6qFwPLgQtHTIK0APhMkk3A/2Iwox0M/ut+Rjfu/bKqemC6ip4iK4GLuhC9DDh5b427uUxOBP4OOAs4v/cK9XTt6dra2sO+Ztfi2gMGkjyPQS/wpUmKwY0jBXxqT8+pqu8An07yGWB7kudV1d3TUvAUqqq/TXIIsHDCrvcC/wy8nMEf6oe69tckeQ3wJgY30fxRVV04nTU/VUmOApYCV3V/b/YDvstg2tQ9qqpNwKYknwe+B5zeb6V6mu4G/sWEbc9l8LObuO+5NJyQyB7wwEnAhVX1gqpaUlVHMPhhHT6qcZI3DfUYlwKPAvdNT6lTq7viYx7dOOeQg4A7u57iKV0bkrwAuKuqPsPgTsZjp7Hcp2sV8JHuZ7ykqp4PHNa9pidIckCSE4Y2HQ18fxrq1NNQVQ8CdyY5ESDJcxn8T+9a4OvArw/9/p4GfK1FnWAPeLdVwH+bsO1S4IMMxgm3Dm1/L/A24ONJfgTsAt5eVY9OS6VTY/cYMAxmpDutqh6dMArxKeDSJCcz+Af6w277CcD7kzwCPAicOj0lT4mVDD4gYNhfdNuvYzAf9fDPehVwdpL/Duxk8D04fRrq1NN3KvDJJH/crX+0qr6TZC3wYmBj97/d9cAHWhXprciS1IhDEJLUiAEsSY0YwJLUiAEsSY0YwJLUiAGsGS/JP3Y3k0zFsd6Z5NRu+fQkz+/jPBJ4HbD0E0nmV9WaoU2nAzfxxA+TlaaEAawZJcmXGHyS9v7An1bV2gn7/wB4O3Abg1tMr6+qjyU5GljDYPKg7wC/UVX3dhMq/T8GM+GtS3IggxtM/pHBfB9fSLITeHV3it9J8hYGc2WcXFX/0M2LcSSDiY3+FfAfgVcxuOnjduAtVfVID98OzXAOQWim+Y2qegWDcHx3N48HAN1E228DjgHe2rXZ7ULgP1XVUcAm4MND+w6uqtdW1e67pqiqSxjcJfX2buKind2uHVV1LPBpBpPz7PZCBvNjrAD+J/C1qnoZgzvo3jQFr1uzkAGsmebdSTYC32TQE146tO/fAH9ZVTu7Wdq+DNB98sXBVXV11+4C4DVDz7t4H85/Wfd4PY+fnP2rXS93E4N5M3bPkLcJJ3HXHjgEoRmjmxjnF4FXV9WPuuGD/YebPMVD/3DyJj/xcPf4KI///XkYoKoeS/JI/fQe/8fw90x7YA9YM8lBwL1d+L6YwTjrsGuBtyTZv/uEkzcBVNX9wL1Dn95xCnA1k3uAwadiSL3wL7NmkiuAdya5EbiVwTDET1TVt7pPsNjIYNrI9cD93e7TgDVJns1gDuAznsT5Ptc9Z/hNOGnKOBuaZpUkB1TVg13QXgOsrqobWtcljWIPWLPN2iQvYTA2fIHhq3FmD1iSGvFNOElqxACWpEYMYElqxACWpEYMYElq5P8DjSqINGQK7V0AAAAASUVORK5CYII=\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAWAAAAFgCAYAAACFYaNMAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjMsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+AADFEAAAVTklEQVR4nO3df7DddX3n8efLJIgWhFXSAQGFtVkdq/LDDMVlq6zU3ajYbBV2k1V+tU5qR2p11Wx1Wn8ws9OttXXWYmXjygiuo3SBtdFFWHarIN1KDWkg/ChO1FoCpNwQfmpAAu/943yjh8u5uYnc7/2ce+/zMXPnfH98zvf7PvfevO4nn/P9fk6qCknS7HtG6wIkaaEygCWpEQNYkhoxgCWpEQNYkhpZ3LqAfbVixYq68sorW5chSfsiozbOuR7w9u3bW5cgSTNizgWwJM0XBrAkNWIAS1IjBrAkNWIAS1IjBrAkNWIAS1IjvQVwkv2T/E2SG5PckuSjI9o8M8klSbYkuT7JUX3VI0njps8e8KPAa6vqGOBYYEWSEye1+Q3gvqr6BeATwB/2WI8kjZXeArgGHu5Wl3Rfk2d/Xwlc1C1fCpySZOQte5I03/Q6BpxkUZJNwD3A1VV1/aQmhwN3AFTVLuAB4Hl91iRJ46LXAK6qx6vqWOAI4IQkL5vUZFRv9ymfkZRkTZINSTZMTEz0UaokzbpZuQqiqu4HvgGsmLRrK3AkQJLFwEHAjhHPX1dVy6tq+dKlS3uuVgvR2rVrOfPMM1m7dm3rUrSA9HkVxNIkB3fLzwJ+Bfi7Sc3WA2d1y6cBf1l+Sqga2LZtG3feeSfbtm1rXYoWkD7nAz4MuCjJIgZB/+dV9dUk5wEbqmo98Fng80m2MOj5ruqxHkkaK70FcFXdBBw3YvuHhpYfAU7vqwZJGmdz7hMxtHCd9Kcn9Xbs/e7fj2fwDO64/47ezvNXv/1XvRxXc5e3IktSIwawJDViAEtSIwawJDXim3ASUM8unuAJ6tlehq7ZYwBLwGMnPda6BC1ADkFIUiMGsCQ1YgBLUiMGsCQ1YgBLUiMGsCQ1YgBLUiMGsCQ1YgBLUiMGsCQ1YgBLUiMGsCQ1YgBLUiMGsCQ1YgBLUiMGsCQ1YgBLUiMGsCQ1YgBLUiMGsCQ1YgBLUiMGsCQ1YgBLUiMGsCQ1YgBLUiMGsCQ1YgBLUiMGsCQ1YgBLUiMGsCQ1YgBLUiMGsCQ1YgBLUiMGsCQ10lsAJzkyydeT3JbkliS/M6LNyUkeSLKp+/pQX/VI0rhZ3OOxdwHvraqNSQ4EbkhydVXdOqndN6vq1B7rkKSx1FsPuKrurqqN3fJDwG3A4X2dT5LmmlkZA05yFHAccP2I3a9KcmOSryX5xSmevybJhiQbJiYmeqxUkmZP7wGc5ADgMuDdVfXgpN0bgRdW1THAnwJfHnWMqlpXVcuravnSpUv7LViSZkmvAZxkCYPw/UJVXT55f1U9WFUPd8tXAEuSHNJnTZI0Lvq8CiLAZ4HbqupPpmhzaNeOJCd09dzbV02SNE76vAriJOAMYHOSTd22DwIvAKiqC4DTgN9KsgvYCayqquqxJkkaG70FcFVdB2SaNucD5/dVgySNM++Ek6RGDGBJasQAlqRGDGBJasQAlqRGDGBJasQAlqRGDGBJasQAlqRGDGBJasQAlqRGDGBJasQAlqRGDGBJasQAlqRGDGBJasQAlqRGDGBJasQAlqRGDGBJasQAlqRGDGBJasQAlqRGDGBJasQAlqRGDGBJasQAlqRGDGBJasQAlqRGDGBJasQAlqRGDGBJasQAlqRGDGBJasQAlqRGDGBJasQAlqRGDGBJasQAlqRGDGBJaqS3AE5yZJKvJ7ktyS1JfmdEmyT5ZJItSW5Kcnxf9UjSuFnc47F3Ae+tqo1JDgRuSHJ1Vd061Ob1wLLu65eAT3ePkjTv9dYDrqq7q2pjt/wQcBtw+KRmK4GLa+BbwMFJDuurJkkaJ7MyBpzkKOA44PpJuw4H7hha38pTQ5oka5JsSLJhYmKirzIlaVb1HsBJDgAuA95dVQ9O3j3iKfWUDVXrqmp5VS1funRpH2VK0qzrNYCTLGEQvl+oqstHNNkKHDm0fgRwV581SdK46PMqiACfBW6rqj+Zotl64MzuaogTgQeq6u6+apKkcdLnVRAnAWcAm5Ns6rZ9EHgBQFVdAFwBvAHYAvwIOKfHeiRprPQWwFV1HaPHeIfbFPDOvmqQpHHmnXCS1IgBLEmNGMCS1IgBLEmNGMCS1IgBLEmNGMCS1IgBLEmNGMCS1IgBLEmNGMCS1IgBLEmNGMCS1IgBLEmNGMCS1IgBLEmNGMCS1IgBLEmNGMCS1IgBLEmNGMCS1IgBLEmNGMCS1IgBLEmNGMCS1IgBLEmN7DGAk7x2aPnoSfve3FdRkrQQTNcD/vjQ8mWT9v3eDNciSQvKdAGcKZZHrUuS9sF0AVxTLI9alyTtg8XT7P+nSdYz6O3uXqZbP3rqp0mSpjNdAK8cWv74pH2T1yVJ+2CPAVxV1wyvJ1kCvAy4s6ru6bMwSZrvprsM7YIkv9gtHwTcCFwM/G2S1bNQnyTNW9O9CffLVXVLt3wO8J2qejnwSmBtr5VJ0jw3XQD/eGj5dcCXAapqW28VSdICMV0A35/k1CTHAScBVwIkWQw8q+/iJGk+m+4qiN8EPgkcCrx7qOd7CvC/+ixMkua76a6C+A6wYsT2q4Cr+ipKkhaCPQZwkk/uaX9VvWtmy5GkhWO6IYh3ADcDfw7cxT7M/5DkQuBU4J6qetmI/ScDfwF8v9t0eVWdt7fHl6S5broAPgw4Hfh3wC7gEuCyqrpvL479OeB8BtcNT+WbVXXqXhxLkuadPV4FUVX3VtUFVfUvgbOBg4Fbkpwx3YGr6lpgx4xUKUnz0F59IkaS44F3A28DvgbcMEPnf1WSG5N8bfcdd1Ocf02SDUk2TExMzNCpJamt6d6E+yiDcdzbgC8BH6iqXTN07o3AC6vq4SRvYHCTx7JRDatqHbAOYPny5U6DKWlemK4H/PvAQcAxwB8AG5PclGRzkpuezomr6sGqerhbvgJYkuSQp3NMSZpLpnsTrrc5f5McCvxjVVWSExj8Mbi3r/NJ0riZ7kaMH4zanmQRsAoYub9r80XgZOCQJFuBDwNLuuNeAJwG/FaSXcBOYFVVObwgacGYbgz4OcA7gcOB9cDVwLnA+4BNwBemem5V7XG6yqo6n8FlapK0IE03BPF54D7gr4G3A+8H9gNWVtWmnmuTpHlt2s+E6+b/Jcl/A7YDL6iqh3qvTJLmuemugnhs90JVPQ583/CVpJkxXQ/4mCQPdssBntWtB6iqek6v1UnSPDbdVRCLZqsQSVpo9upWZEnSzDOAJakRA1iSGjGAJakRA1iSGjGAJakRA1iSGjGAJakRA1iSGjGAJakRA1iSGjGAJakRA1iSGjGAJakRA1iSGjGAJakRA1iSGjGAJakRA1iSGjGAJakRA1iSGjGAJakRA1iSGjGAJakRA1iSGjGAJakRA1iSGjGAJakRA1iSGjGAJakRA1iSGjGAJakRA1iSGjGAJakRA1iSGuktgJNcmOSeJDdPsT9JPplkS5KbkhzfVy2SNI767AF/Dlixh/2vB5Z1X2uAT/dYiySNnd4CuKquBXbsoclK4OIa+BZwcJLD+qpHksZNyzHgw4E7hta3dtueIsmaJBuSbJiYmJiV4iSpby0DOCO21aiGVbWuqpZX1fKlS5f2XJYkzY6WAbwVOHJo/Qjgrka1SNKsaxnA64Ezu6shTgQeqKq7G9YjSbNqcV8HTvJF4GTgkCRbgQ8DSwCq6gLgCuANwBbgR8A5fdUiSeOotwCuqtXT7C/gnX2dX5LGnXfCSVIjvfWANbetXbuWbdu2ceihh/Kxj32sdTnS0zKuv88GsEbatm0bd955Z+sypBkxrr/PBvBeGNe/npLmNgN4L4zrX89/OO/lvR17147nAovZteMHvZ3nBR/a3MtxNb1x7FSc/96v9Hbs+7f/8CePfZ7n3D9+0z61N4ClBWhcOxULzbwJ4Fe+/+Lejn3g9odYBPzD9od6O88Nf3RmL8eVNL7mTQBrZh2y/xPAru5RLVzz6tf0duydixdBws6tW3s7z2uuvaaX4/4sfm6/5zzpcVwYwBrpfa+4v3UJ0ow56UVvbl3CSAbwXnhiv5970qMkzQQDeC/8cNm/al2CNKMOrnrSo9owgKUF6G2PO7Y/DpwLQpIaMYAlqREDWJIaMYAlqREDWJIaMYAlqREDWJIaMYAlqREDWJIaMYAlqREDWJIaMYAlqREDWJIaMYAlqREDWJIaMYAlqREDWJIaMYAlqREDWJIaMYAlqREDWJIaMYAlqREDWJIaMYAlqREDWJIaMYAlqREDWJIaMYAlqZFeAzjJiiS3J9mS5HdH7D87yUSSTd3X2/usR5LGyeK+DpxkEfAp4HXAVuDbSdZX1a2Tml5SVef2VYckjas+e8AnAFuq6ntV9WPgS8DKHs8nSXNKnwF8OHDH0PrWbttkb0lyU5JLkxzZYz2SNFb6DOCM2FaT1r8CHFVVrwD+D3DRyAMla5JsSLJhYmJihsuUpDb6DOCtwHCP9gjgruEGVXVvVT3arX4GeOWoA1XVuqpaXlXLly5d2kuxkjTb+gzgbwPLkhydZD9gFbB+uEGSw4ZWfxW4rcd6JGms9HYVRFXtSnIucBWwCLiwqm5Jch6woarWA+9K8qvALmAHcHZf9UjSuOktgAGq6grgiknbPjS0/AHgA33WIEnjyjvhJKkRA1iSGjGAJakRA1iSGjGAJakRA1iSGjGAJakRA1iSGjGAJakRA1iSGjGAJakRA1iSGjGAJakRA1iSGjGAJakRA1iSGjGAJakRA1iSGjGAJakRA1iSGjGAJakRA1iSGjGAJakRA1iSGjGAJakRA1iSGjGAJakRA1iSGjGAJakRA1iSGjGAJakRA1iSGjGAJakRA1iSGjGAJakRA1iSGjGAJakRA1iSGjGAJakRA1iSGjGAJamRXgM4yYoktyfZkuR3R+x/ZpJLuv3XJzmqz3okaZz0FsBJFgGfAl4PvBRYneSlk5r9BnBfVf0C8AngD/uqR5LGTZ894BOALVX1var6MfAlYOWkNiuBi7rlS4FTkqTHmiRpbKSq+jlwchqwoqre3q2fAfxSVZ071Obmrs3Wbv27XZvtk461BljTrb4YuL2XovfsEGD7tK3ml4X2mn2981vL17u9qlZM3ri4xxOO6slOTvu9aUNVrQPWzURRP6skG6pqecsaZttCe82+3vltHF9vn0MQW4Ejh9aPAO6aqk2SxcBBwI4ea5KksdFnAH8bWJbk6CT7AauA9ZParAfO6pZPA/6y+hoTkaQx09sQRFXtSnIucBWwCLiwqm5Jch6woarWA58FPp9kC4Oe76q+6pkBTYdAGllor9nXO7+N3evt7U04SdKeeSecJDViAEtSIwbwkCS/lqSSvKRbP6q7VnlyuxO7W6c3JbktyUdmvdinIcnjXe03JtmY5J9325+f5NLW9c20JA9PWn9PkkeSHDS07eQkXx3x3FOT/G33vbo1yW/ORs192v39mOr3e64b9bqSfCTJ+5J8I8nyPbWdTX1eBzwXrQauY/Bm4Ef20O4i4N9W1Y3dLdcvnoXaZtLOqjoWIMm/Bv4AeE1V3cXgapT5bjWDq3R+DfjcVI2SLGHwxs0JVbU1yTOBo2ajQC0M9oA7SQ4ATmIwP8V0V2P8PHA3QFU9XlW39lxen54D3AdP7g10y9/sesjDveTDklzb9aBvTvLLDWvfZ0leBBwA/B6DIN6TAxl0Uu4FqKpHq6rFXZiap+wB/9S/Aa6squ8k2ZHkeKa+KeQTwO1JvgFcCVxUVY/MUp0z4VlJNgH7A4cBrx3R5h7gdVX1SJJlwBeB5cC/B66qqv/U9f6fPVtFz5DVDF7LN4EXJ/n5qrpnVMOq2pFkPfCDJP8X+Crwxap6YvbK1XxmD/inVjOYMIjuccreUVWdxyCM/jeDQLqy9+pm1s6qOraqXgKsAC4eMQnSEuAzSTYD/4PBjHYw+K/7Od2498ur6qHZKnqGrAK+1IXo5cDpe2rczWVyCvA3wPuAC3uvUE/XVNfW1hT7ml2Law8YSPI8Br3AlyUpBjeOFPBnUz2nqr4LfDrJZ4CJJM+rqntnpeAZVFV/neQQYOmkXe8B/hE4hsEf6ke69tcmeTXwRgY30fxRVV08mzX/rJK8AlgGXN39vdkP+B6DaVOnVFWbgc1JPg98Hzi730r1NN0L/JNJ257L4Gc3ed9zaTghkT3ggdOAi6vqhVV1VFUdyeCHdcSoxkneONRjXAY8Dtw/O6XOrO6Kj0V045xDDgLu7nqKZ3RtSPJC4J6q+gyDOxmPn8Vyn67VwEe6n/FRVfV84PDuNT1FkgOSnDy06VjgB7NQp56GqnoYuDvJKQBJnsvgf3rXAd8A3jb07/cs4Ost6gR7wLutBv7zpG2XAR9kME64dWj7e4C3AJ9I8iNgF/DWqnp8ViqdGbvHgGEwI91ZVfX4pFGIPwMuS3I6g1/QH3bbTwben+Qx4GHgzNkpeUasYvABAcP+Z7f9egbzUQ//rFcDa5P8V2Ang+/B2bNQp56+M4FPJfnjbv2jVfXdJOuAlwA3dv/b3QB8oFWR3oosSY04BCFJjRjAktSIASxJjRjAktSIASxJjRjAmvOS/H13M8lMHOsdSc7sls9O8vw+ziOB1wFLP5FkcVVdMLTpbOBmnvphstKMMIA1pyT5MoNP0t4f+C9VtW7S/t8H3grcweAW0xuq6uNJjgUuYDB50HeBX6+q+7oJlf4fg5nw1ic5kMENJn/PYL6PLyTZCbyqO8VvJ3kTg7kyTq+qv+vmxTiawcRG/wz4D8CJDG76uBN4U1U91sO3Q3OcQxCaa369ql7JIBzf1c3jAUA30fZbgOOAN3dtdrsY+I9V9QpgM/DhoX0HV9Vrqmr3XVNU1aUM7pJ6azdx0c5u1/aqOh74NIPJeXZ7EYP5MVYC/x34elW9nMEddG+cgdetecgA1lzzriQ3At9i0BNeNrTvXwB/UVU7u1navgLQffLFwVV1TdfuIuDVQ8+7ZB/Of3n3eANPnpz9a10vdzODeTN2z5C3GSdx1xQcgtCc0U2M8yvAq6rqR93wwf7DTX7GQ/9w+iY/8Wj3+DhP/vfzKEBVPZHksfrpPf5P4L8zTcEesOaSg4D7uvB9CYNx1mHXAW9Ksn/3CSdvBKiqB4D7hj694wzgGqb3EINPxZB64V9mzSVXAu9IchNwO4NhiJ+oqm93n2BxI4NpIzcAD3S7zwIuSPJsBnMAn7MX5/tc95zhN+GkGeNsaJpXkhxQVQ93QXstsKaqNrauSxrFHrDmm3VJXspgbPgiw1fjzB6wJDXim3CS1IgBLEmNGMCS1IgBLEmNGMCS1Mj/BwIrgvqmDO8kAAAAAElFTkSuQmCC\n",
       "text/plain": [
        "<Figure size 360x360 with 1 Axes>"
       ]
@@ -1342,10 +1342,10 @@
    "execution_count": null,
    "metadata": {
     "papermill": {
-     "duration": 0.017002,
-     "end_time": "2020-03-22T18:56:32.733954",
+     "duration": 0.020001,
+     "end_time": "2020-03-23T18:53:50.461629",
      "exception": false,
-     "start_time": "2020-03-22T18:56:32.716952",
+     "start_time": "2020-03-23T18:53:50.441628",
      "status": "completed"
     },
     "tags": []
@@ -1373,8 +1373,8 @@
    "version": "3.7.6"
   },
   "papermill": {
-   "duration": 29.170579,
-   "end_time": "2020-03-22T18:56:33.158078",
+   "duration": 33.076955,
+   "end_time": "2020-03-23T18:53:50.485630",
    "environment_variables": {},
    "exception": null,
    "input_path": "eval-report.ipynb",
@@ -1382,8 +1382,8 @@
    "parameters": {
     "dataset": "ml100k"
    },
-   "start_time": "2020-03-22T18:56:03.987499",
-   "version": "1.2.1"
+   "start_time": "2020-03-23T18:53:17.408675",
+   "version": "2.0.0"
   }
  },
  "nbformat": 4,

--- a/eval-report.ml100k.ipynb.dvc
+++ b/eval-report.ml100k.ipynb.dvc
@@ -1,23 +1,22 @@
-md5: 4faf0881081ec11d174b1a525de08920
+md5: 6b1b6658f02cdc19e1b807cb3b61657f
 cmd: papermill -r dataset ml100k eval-report.ipynb eval-report.ml100k.ipynb
-wdir: .
 deps:
 - path: output/ml100k-Bias
-  md5: f57cbf9baad88803d7a67ad4b317b388.dir
+  md5: 207481bbf294d0d5c8efa7f02d533941.dir
 - path: output/ml100k-Pop
-  md5: a31d3ba9d957b44c84a620e4680d700c.dir
-- md5: 133fb6eb30f059665df9cdf11558b552.dir
+  md5: 9097cb72d506821f3838fb8f480074d5.dir
+- md5: a61b739c076ecbdca30fb42d1845a7b9.dir
   path: output/ml100k-ALS
-- md5: 17dbc4d3edf7860b1f5cee6700d711fc.dir
+- md5: fbfc5a89096a4642f911fc5f7482b32c.dir
   path: output/ml100k-IALS
-- md5: be34a158cba6c257ab2f9ec168203cab.dir
+- md5: 391fda6fc3d54f2aeb676b4e01360c9c.dir
   path: output/ml100k-II
-- md5: 2c7fe862338a391b34da6bf1327d9f40.dir
+- md5: b6f5d09b288620a53a65f136b93fb546.dir
   path: output/ml100k-UU
-- md5: 22203b9e4f7df91bd5d6dc68cc09f7ce
+- md5: a8a899911433f2ef1f50722ea4707546
   path: eval-report.ipynb
 outs:
-- md5: 277c98cd6b18017c7d252b388b83af9b
+- md5: 5dc13758acb5136b1c101574433845ef
   path: eval-report.ml100k.ipynb
   cache: false
   metric: false

--- a/eval-report.ml20m.ipynb
+++ b/eval-report.ml20m.ipynb
@@ -4,10 +4,10 @@
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.072741,
-     "end_time": "2020-03-23T14:31:18.808098",
+     "duration": 0.018179,
+     "end_time": "2020-03-24T20:36:00.724444",
      "exception": false,
-     "start_time": "2020-03-23T14:31:18.735357",
+     "start_time": "2020-03-24T20:36:00.706265",
      "status": "completed"
     },
     "tags": []
@@ -20,10 +20,10 @@
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.069982,
-     "end_time": "2020-03-23T14:31:18.949151",
+     "duration": 0.017293,
+     "end_time": "2020-03-24T20:36:00.758827",
      "exception": false,
-     "start_time": "2020-03-23T14:31:18.879169",
+     "start_time": "2020-03-24T20:36:00.741534",
      "status": "completed"
     },
     "tags": []
@@ -36,10 +36,10 @@
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.069968,
-     "end_time": "2020-03-23T14:31:19.089704",
+     "duration": 0.016576,
+     "end_time": "2020-03-24T20:36:00.792394",
      "exception": false,
-     "start_time": "2020-03-23T14:31:19.019736",
+     "start_time": "2020-03-24T20:36:00.775818",
      "status": "completed"
     },
     "tags": []
@@ -52,10 +52,10 @@
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.070189,
-     "end_time": "2020-03-23T14:31:19.230640",
+     "duration": 0.016602,
+     "end_time": "2020-03-24T20:36:00.825732",
      "exception": false,
-     "start_time": "2020-03-23T14:31:19.160451",
+     "start_time": "2020-03-24T20:36:00.809130",
      "status": "completed"
     },
     "tags": []
@@ -70,10 +70,10 @@
    "execution_count": 1,
    "metadata": {
     "papermill": {
-     "duration": 0.085608,
-     "end_time": "2020-03-23T14:31:19.386820",
+     "duration": 0.022839,
+     "end_time": "2020-03-24T20:36:00.865019",
      "exception": false,
-     "start_time": "2020-03-23T14:31:19.301212",
+     "start_time": "2020-03-24T20:36:00.842180",
      "status": "completed"
     },
     "tags": []
@@ -87,10 +87,10 @@
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.069727,
-     "end_time": "2020-03-23T14:31:19.527354",
+     "duration": 0.022208,
+     "end_time": "2020-03-24T20:36:00.903868",
      "exception": false,
-     "start_time": "2020-03-23T14:31:19.457627",
+     "start_time": "2020-03-24T20:36:00.881660",
      "status": "completed"
     },
     "tags": []
@@ -104,10 +104,10 @@
    "execution_count": 2,
    "metadata": {
     "papermill": {
-     "duration": 4.064468,
-     "end_time": "2020-03-23T14:31:23.662886",
+     "duration": 0.853345,
+     "end_time": "2020-03-24T20:36:01.775580",
      "exception": false,
-     "start_time": "2020-03-23T14:31:19.598418",
+     "start_time": "2020-03-24T20:36:00.922235",
      "status": "completed"
     },
     "tags": []
@@ -127,10 +127,10 @@
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.069471,
-     "end_time": "2020-03-23T14:31:23.803717",
+     "duration": 0.017055,
+     "end_time": "2020-03-24T20:36:01.811342",
      "exception": false,
-     "start_time": "2020-03-23T14:31:23.734246",
+     "start_time": "2020-03-24T20:36:01.794287",
      "status": "completed"
     },
     "tags": []
@@ -144,10 +144,10 @@
    "execution_count": 3,
    "metadata": {
     "papermill": {
-     "duration": 1.792672,
-     "end_time": "2020-03-23T14:31:25.667411",
+     "duration": 0.929779,
+     "end_time": "2020-03-24T20:36:02.757518",
      "exception": false,
-     "start_time": "2020-03-23T14:31:23.874739",
+     "start_time": "2020-03-24T20:36:01.827739",
      "status": "completed"
     },
     "tags": []
@@ -157,7 +157,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/home/MICHAELEKSTRAND/anaconda3/envs/lk-demo/lib/python3.7/site-packages/fastparquet/dataframe.py:5: FutureWarning: pandas.core.index is deprecated and will be removed in a future version.  The public classes are available in the top-level namespace.\n",
+      "/home/mekstrand/miniconda3/envs/lk-demo/lib/python3.7/site-packages/fastparquet/dataframe.py:5: FutureWarning: pandas.core.index is deprecated and will be removed in a future version.  The public classes are available in the top-level namespace.\n",
       "  from pandas.core.index import CategoricalIndex, RangeIndex, Index, MultiIndex\n"
      ]
     }
@@ -171,10 +171,10 @@
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.070657,
-     "end_time": "2020-03-23T14:31:25.810799",
+     "duration": 0.016944,
+     "end_time": "2020-03-24T20:36:02.792946",
      "exception": false,
-     "start_time": "2020-03-23T14:31:25.740142",
+     "start_time": "2020-03-24T20:36:02.776002",
      "status": "completed"
     },
     "tags": []
@@ -187,10 +187,10 @@
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.040186,
-     "end_time": "2020-03-23T14:31:25.894619",
+     "duration": 0.016899,
+     "end_time": "2020-03-24T20:36:02.826703",
      "exception": false,
-     "start_time": "2020-03-23T14:31:25.854433",
+     "start_time": "2020-03-24T20:36:02.809804",
      "status": "completed"
     },
     "tags": []
@@ -204,10 +204,10 @@
    "execution_count": 4,
    "metadata": {
     "papermill": {
-     "duration": 0.083988,
-     "end_time": "2020-03-23T14:31:26.019002",
+     "duration": 0.022097,
+     "end_time": "2020-03-24T20:36:02.865638",
      "exception": false,
-     "start_time": "2020-03-23T14:31:25.935014",
+     "start_time": "2020-03-24T20:36:02.843541",
      "status": "completed"
     },
     "tags": [
@@ -224,10 +224,10 @@
    "execution_count": 5,
    "metadata": {
     "papermill": {
-     "duration": 0.087139,
-     "end_time": "2020-03-23T14:31:26.178114",
+     "duration": 0.021438,
+     "end_time": "2020-03-24T20:36:02.904318",
      "exception": false,
-     "start_time": "2020-03-23T14:31:26.090975",
+     "start_time": "2020-03-24T20:36:02.882880",
      "status": "completed"
     },
     "tags": [
@@ -245,10 +245,10 @@
    "execution_count": 6,
    "metadata": {
     "papermill": {
-     "duration": 0.085974,
-     "end_time": "2020-03-23T14:31:26.339778",
+     "duration": 0.02165,
+     "end_time": "2020-03-24T20:36:02.942632",
      "exception": false,
-     "start_time": "2020-03-23T14:31:26.253804",
+     "start_time": "2020-03-24T20:36:02.920982",
      "status": "completed"
     },
     "tags": []
@@ -263,10 +263,10 @@
    "execution_count": 7,
    "metadata": {
     "papermill": {
-     "duration": 0.065467,
-     "end_time": "2020-03-23T14:31:26.477481",
+     "duration": 0.022514,
+     "end_time": "2020-03-24T20:36:02.982101",
      "exception": false,
-     "start_time": "2020-03-23T14:31:26.412014",
+     "start_time": "2020-03-24T20:36:02.959587",
      "status": "completed"
     },
     "tags": []
@@ -281,10 +281,10 @@
    "execution_count": 8,
    "metadata": {
     "papermill": {
-     "duration": 102.725251,
-     "end_time": "2020-03-23T14:33:09.243909",
+     "duration": 55.562017,
+     "end_time": "2020-03-24T20:36:58.561226",
      "exception": false,
-     "start_time": "2020-03-23T14:31:26.518658",
+     "start_time": "2020-03-24T20:36:02.999209",
      "status": "completed"
     },
     "tags": []
@@ -308,10 +308,10 @@
    "execution_count": 9,
    "metadata": {
     "papermill": {
-     "duration": 3.996808,
-     "end_time": "2020-03-23T14:33:13.314050",
+     "duration": 2.656985,
+     "end_time": "2020-03-24T20:37:01.236704",
      "exception": false,
-     "start_time": "2020-03-23T14:33:09.317242",
+     "start_time": "2020-03-24T20:36:58.579719",
      "status": "completed"
     },
     "tags": []
@@ -333,10 +333,10 @@
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.067727,
-     "end_time": "2020-03-23T14:33:13.454471",
+     "duration": 0.017219,
+     "end_time": "2020-03-24T20:37:01.271070",
      "exception": false,
-     "start_time": "2020-03-23T14:33:13.386744",
+     "start_time": "2020-03-24T20:37:01.253851",
      "status": "completed"
     },
     "tags": []
@@ -350,10 +350,10 @@
    "execution_count": 10,
    "metadata": {
     "papermill": {
-     "duration": 0.05433,
-     "end_time": "2020-03-23T14:33:13.549355",
+     "duration": 0.023403,
+     "end_time": "2020-03-24T20:37:01.311891",
      "exception": false,
-     "start_time": "2020-03-23T14:33:13.495025",
+     "start_time": "2020-03-24T20:37:01.288488",
      "status": "completed"
     },
     "tags": []
@@ -369,10 +369,10 @@
    "execution_count": 11,
    "metadata": {
     "papermill": {
-     "duration": 0.447923,
-     "end_time": "2020-03-23T14:33:14.053576",
+     "duration": 0.398944,
+     "end_time": "2020-03-24T20:37:01.728091",
      "exception": false,
-     "start_time": "2020-03-23T14:33:13.605653",
+     "start_time": "2020-03-24T20:37:01.329147",
      "status": "completed"
     },
     "tags": []
@@ -380,7 +380,7 @@
    "outputs": [],
    "source": [
     "test = []\n",
-    "for file in split_dir.glob(\"test-*.csv\"):\n",
+    "for file in split_dir.glob(\"test-*.csv.gz\"):\n",
     "    test.append(pd.read_csv(file, sep=','))\n",
     "\n",
     "test = pd.concat(test, ignore_index=True)"
@@ -390,10 +390,10 @@
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.041809,
-     "end_time": "2020-03-23T14:33:14.137818",
+     "duration": 0.016875,
+     "end_time": "2020-03-24T20:37:01.761988",
      "exception": false,
-     "start_time": "2020-03-23T14:33:14.096009",
+     "start_time": "2020-03-24T20:37:01.745113",
      "status": "completed"
     },
     "tags": []
@@ -406,10 +406,10 @@
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.071751,
-     "end_time": "2020-03-23T14:33:14.279715",
+     "duration": 0.016695,
+     "end_time": "2020-03-24T20:37:01.795860",
      "exception": false,
-     "start_time": "2020-03-23T14:33:14.207964",
+     "start_time": "2020-03-24T20:37:01.779165",
      "status": "completed"
     },
     "tags": []
@@ -423,10 +423,10 @@
    "execution_count": 12,
    "metadata": {
     "papermill": {
-     "duration": 7510.017705,
-     "end_time": "2020-03-23T16:38:24.360150",
+     "duration": 4649.952081,
+     "end_time": "2020-03-24T21:54:31.764890",
      "exception": false,
-     "start_time": "2020-03-23T14:33:14.342445",
+     "start_time": "2020-03-24T20:37:01.812809",
      "status": "completed"
     },
     "tags": []
@@ -479,23 +479,23 @@
        "      <th>1</th>\n",
        "      <td>100.0</td>\n",
        "      <td>0.00</td>\n",
-       "      <td>0.000</td>\n",
+       "      <td>0.000000</td>\n",
        "      <td>0.000000</td>\n",
        "      <td>5</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
        "      <td>100.0</td>\n",
-       "      <td>0.00</td>\n",
-       "      <td>0.000</td>\n",
-       "      <td>0.000000</td>\n",
+       "      <td>0.02</td>\n",
+       "      <td>0.111111</td>\n",
+       "      <td>0.154893</td>\n",
        "      <td>5</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
        "      <td>100.0</td>\n",
        "      <td>0.00</td>\n",
-       "      <td>0.000</td>\n",
+       "      <td>0.000000</td>\n",
        "      <td>0.000000</td>\n",
        "      <td>5</td>\n",
        "    </tr>\n",
@@ -503,16 +503,16 @@
        "      <th>4</th>\n",
        "      <td>100.0</td>\n",
        "      <td>0.00</td>\n",
-       "      <td>0.000</td>\n",
+       "      <td>0.000000</td>\n",
        "      <td>0.000000</td>\n",
        "      <td>5</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>5</th>\n",
        "      <td>100.0</td>\n",
-       "      <td>0.01</td>\n",
-       "      <td>0.125</td>\n",
-       "      <td>0.104063</td>\n",
+       "      <td>0.02</td>\n",
+       "      <td>0.022222</td>\n",
+       "      <td>0.084485</td>\n",
        "      <td>5</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
@@ -522,11 +522,11 @@
       "text/plain": [
        "                        nrecs  precision  recip_rank      ndcg  ntruth\n",
        "dataset algorithm user                                                \n",
-       "ml20m   ALS       1     100.0       0.00       0.000  0.000000       5\n",
-       "                  2     100.0       0.00       0.000  0.000000       5\n",
-       "                  3     100.0       0.00       0.000  0.000000       5\n",
-       "                  4     100.0       0.00       0.000  0.000000       5\n",
-       "                  5     100.0       0.01       0.125  0.104063       5"
+       "ml20m   ALS       1     100.0       0.00    0.000000  0.000000       5\n",
+       "                  2     100.0       0.02    0.111111  0.154893       5\n",
+       "                  3     100.0       0.00    0.000000  0.000000       5\n",
+       "                  4     100.0       0.00    0.000000  0.000000       5\n",
+       "                  5     100.0       0.02    0.022222  0.084485       5"
       ]
      },
      "execution_count": 12,
@@ -549,10 +549,10 @@
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.040739,
-     "end_time": "2020-03-23T16:38:24.471284",
+     "duration": 0.01809,
+     "end_time": "2020-03-24T21:54:31.801226",
      "exception": false,
-     "start_time": "2020-03-23T16:38:24.430545",
+     "start_time": "2020-03-24T21:54:31.783136",
      "status": "completed"
     },
     "tags": []
@@ -566,10 +566,10 @@
    "execution_count": 13,
    "metadata": {
     "papermill": {
-     "duration": 0.408848,
-     "end_time": "2020-03-23T16:38:24.921069",
+     "duration": 0.251217,
+     "end_time": "2020-03-24T21:54:32.070592",
      "exception": false,
-     "start_time": "2020-03-23T16:38:24.512221",
+     "start_time": "2020-03-24T21:54:31.819375",
      "status": "completed"
     },
     "tags": []
@@ -608,47 +608,47 @@
        "      <td>ALS</td>\n",
        "      <td>1</td>\n",
        "      <td>precision</td>\n",
-       "      <td>0.0</td>\n",
+       "      <td>0.000000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
        "      <td>ALS</td>\n",
        "      <td>1</td>\n",
        "      <td>recip_rank</td>\n",
-       "      <td>0.0</td>\n",
+       "      <td>0.000000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
        "      <td>ALS</td>\n",
        "      <td>1</td>\n",
        "      <td>ndcg</td>\n",
-       "      <td>0.0</td>\n",
+       "      <td>0.000000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
        "      <td>ALS</td>\n",
        "      <td>2</td>\n",
        "      <td>precision</td>\n",
-       "      <td>0.0</td>\n",
+       "      <td>0.020000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
        "      <td>ALS</td>\n",
        "      <td>2</td>\n",
        "      <td>recip_rank</td>\n",
-       "      <td>0.0</td>\n",
+       "      <td>0.111111</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "  algorithm  user      metric  val\n",
-       "0       ALS     1   precision  0.0\n",
-       "1       ALS     1  recip_rank  0.0\n",
-       "2       ALS     1        ndcg  0.0\n",
-       "3       ALS     2   precision  0.0\n",
-       "4       ALS     2  recip_rank  0.0"
+       "  algorithm  user      metric       val\n",
+       "0       ALS     1   precision  0.000000\n",
+       "1       ALS     1  recip_rank  0.000000\n",
+       "2       ALS     1        ndcg  0.000000\n",
+       "3       ALS     2   precision  0.020000\n",
+       "4       ALS     2  recip_rank  0.111111"
       ]
      },
      "execution_count": 13,
@@ -666,10 +666,10 @@
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.073554,
-     "end_time": "2020-03-23T16:38:25.068660",
+     "duration": 0.018585,
+     "end_time": "2020-03-24T21:54:32.107942",
      "exception": false,
-     "start_time": "2020-03-23T16:38:24.995106",
+     "start_time": "2020-03-24T21:54:32.089357",
      "status": "completed"
     },
     "tags": []
@@ -683,10 +683,10 @@
    "execution_count": 14,
    "metadata": {
     "papermill": {
-     "duration": 24.879055,
-     "end_time": "2020-03-23T16:38:50.021244",
+     "duration": 16.055571,
+     "end_time": "2020-03-24T21:54:48.181901",
      "exception": false,
-     "start_time": "2020-03-23T16:38:25.142189",
+     "start_time": "2020-03-24T21:54:32.126330",
      "status": "completed"
     },
     "tags": []
@@ -694,7 +694,7 @@
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAwIAAADQCAYAAAC0otYBAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjMsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+AADFEAAAePUlEQVR4nO3dfbhcZXnv8e+PYEQIIEg8qbwIR6MWhUKNaA1VWpHisYBt4QC1StSW2lO0vmBqe06R4rmOGuvRVrBKlSpWRUWt0YMgtQIaRRNew6sC8pLArkCAAiIScp8/1ooO251k7509mdl7fT/XNdeetdaz1nPP7Lln5l5rPbNSVUiSJEnqlq0GHYAkSZKkLc9CQJIkSeogCwFJkiSpgywEJEmSpA6yEJAkSZI6yEJAkiRJ6iALAY0pyX5J/ttGli9I8g9bMqbNtamYkzwlydlbMiZJkqbKdPjsTrIoyamDjEG/YCGgDdkPGPPNJMnWVbWiqt64hWPqjSFJJvT63VTMVXV7VR25+dFJgzMdvghsSJLXJ3n1gPq+Ockug+hbmkJD/dmt4WMhMEMl2TPJdUk+muSqJJ9KcnCSZUl+mOSAtt12Sc5IsjzJZUmOSDIbOAU4OsnlSY5OcnKS05N8HTgzyUFJvtpuY06Sf06yMsmVSf5gM2NflOTLSc5Ncn2Sd/Q8pmuTfAi4FNg9ySFJvpvk0iSfTzKnbfu8JN9JckWS7yfZflTML24f2+Xt496+3f5V7fJteh7TZUl+qye2L7ax/TDJks15rFIfDMUXgSRbT3SdqvpwVZ25pfuVhsUM+Owe8/MxyWuS/CDJhcDCnvn/JcmX2s/qK5K8sJ3/N+3zcH6SzyQ5cXNi00ZUlbcZeAP2BNYC+9AUfJcAZwABjgD+tW33f4A/au8/EfgBsB2wCDi1Z3snt9t4Qjt9EPDV9v57gA/0tN1pjHjeD1w+xu3tY7RdBNwBPAl4AnAVsKB9TOuAF7TtdgEuArZrp/8SOAmYDdwEPK+dvwOw9aiYvwIsbO/PaZfvCVzVznsr8M/t/WcBtwLbtLHdBOzYTt8C7D7o/7e3mXNrX4fXAR9tX/ufAg4GlgE/BA5o223X5vRy4LI2r2e3r9U72/w6us3d04GvA58elQdzgH8GVgJXAn+wmbEvAj7f5te/t/Pe1sZ4JfC3PW1f3c67AvhkO+9k4MT2/gXAB4DvtM/DARvpd/Rj3BP4Fs0Og0uBF7btDmq3e3b7HH8KSLvs5vY95QnAucCfDPq14K17N6b/Z/cvfT4Cv9K+L81t36OWrY8R+Czwpvb+rHbdBW0fTwC2p3nfO3HQ/5uZenPPycz2o6paCZDkauAbVVVJVtK82QAcAhzeU21vA+yxge0traqHxph/MHDM+omqumd0g6p68wRjP7+q7m5j/yJwIPCvwC1VdXHb5gXA3sCyJNC8wXwXeCZwR1Utb/v+z3Y7vdtfBvzfJJ8CvlhVq0YtPxD4YLv+dUluAZ7RLvtGVd3XbvMa4KnAbRN8fNLGPB04Cjie5kv0H9K8Jg8H/hp4BfA/ab5svzbJE4HvA/9GUwwvqKoTAJKcDDwXOLCqHkpyUE8/fwPcV1X7tG13Gh1IkvcDvzVGjGdV1bvHmP8bwL5VtSbJIcB84ACaLzJLk7wIuLuNf2FV3ZVk5w08D9tV1Qvbdc4AnrOBdox6jNsCL62qnyaZD3yG5ssFwP7As4Hbad4HFgLfbpfNAc4CzqzNPDIhbYbp/Nk91ufjLsAFVXVnO/+z/OLz9LdpdgpQVY8C9yU5EPjy+piTfGWCMWgCLARmtod77q/rmV7HL/73odkLeH3vikmeP8b2HtxAPwFqY4FM4svE6O2tn+6NITQFw7Gj+tp3U/FU1buT/D+aUyguTnIw8NNR296Q3uf1UcwjTb3p/EXg/Kpa0xPjITRHLKD5oj0f+DXg7Kq6q+1jzS9tpfGZdvlFSXZI8sSquncDbXsf4+OAU5PsR5Ojz+hp9/2qWgWQ5HKa53N9IfBlYElVfWrcj1aaetP5s3tDn48b7WeMuLSFOEZA5wFvSLs7PMn+7fz7aQ7JjcfXgRPWT4y1V7Gq3lxV+41xG+uNBOClSXZO8gSavZ/LxmhzMbAwydPbfrdN8gyaQ/5PSfK8dv72o88bTvK0qlpZVe8BVtCc/tPrIuCVbdtn0HzBuh5py5jIF4H1ubRHVV27ge1t1heBnvE0vbe3j6OvAO/qifHpVfWx8fTb2tAOgU31+2bgP2gKjgU0RwvX21ghvwx42fr3Q2mIDetn91i+BxyU5ElJHkdztHO9bwB/1vY/K8kONIX5YWnG6s0BXj6BvjRBFgJ6J83esyvTDJR9Zzv/m8De6wccbWIb/xvYqR3YdAVj7z2YqG8Dn6Q5T/ALVbVidIP2MOMi4DNJrqQpDJ5VVT+jOTf6g20859PsLe31pp54HwK+Nmr5h4BZ7R7YzwKLquphpOExHb4InAe8Nr8YxL9rkifTfPj/9yRPaudv6NSgo9vlB9KcwnTfOB/XjjSnB64DXkVz7vF4nERz2tKHxtleGpRh/ez+JVV1B81Yhe/SnL54ac/ivwB+q/2svQR4dnta71Ka8UNfpNlZN97c1wStHyQlDY0ki+g5x1nqkiR70gzme047/fF2+uzeZe3Rsg8AL6TZw35zVf1u+6X6PJovCe8CfhV4oKr+rt3eQTQD7363/YJ+Gs359Y/SDOb94mbEvohRuZvkL4A/bicfoBngeGOS42gGEj8KXFZVi9rxDA9U1d8luYDmi8OLaQb8v7aqvr+Bfn++Xjs9H/gC8BOaL0ZvqKo5vY+9bXcqsKKqPp7kZpqjB3fTjEe4s6oWT/a5kDR5SeZU1QPteJ+LgOOr6tJNraeJsxDQ0LEQkNQWAieOdTRQ0syW5NM0PwayDfCJqnrXgEOasSwEJElDx0JAkvrPQkCSNC0keQ3NOcW9llXVnw8iHkma7iwEJEmSpA6aMb9/fuihh9a555476DAkNSb984vmsjRUJpXL5rE0VDaYxzPm50PvuuuuQYcgaQqYy9L0Zx5L08OMKQQkSZIkjZ+FgCRJktRBFgKSJElSB1kISJIkSR1kISBJkiR10Iz5+VBJkqQuW7x4MSMjI8ybN48lS5YMOhxNAxYCkiRJQ2ThBxdOar3Z181mqwe34rZ7b5vUNpa9Ydmk+tX05alBkiRJUgd5RECSJGkGqG2Ldayjtq1Bh6JpwkJAkiRpBnhk4SODDkHTjKcGSZIkSR3U10IgyaFJrk9yQ5K3j7H8LUmuSXJlkm8keWrPsuOS/LC9HdfPOCVJkqSu6VshkGQWcBrwMmBv4Ngke49qdhmwoKr2Bc4GlrTr7gy8A3g+cADwjiQ79StWSZIkqWv6eUTgAOCGqrqpqn4GnAUc0dugqr5ZVT9pJy8Gdmvv/w5wflWtqap7gPOBQ/sYqyRJktQp/SwEdgVu65le1c7bkNcBX5vIukmOT7IiyYo777xzM8OVNCjmsjT9mcfS9NPPQiBjzBvz96yS/BGwAHjvRNatqtOrakFVLZg7d+6kA5U0WOayNP2Zx9L0089CYBWwe8/0bsDtoxslORj4n8DhVfXwRNaVJEmSNDn9LASWA/OT7JVkNnAMsLS3QZL9gY/QFAE/7ll0HnBIkp3aQcKHtPMkSZIkTYG+XVCsqtYmOYHmC/ws4IyqujrJKcCKqlpKcyrQHODzSQBurarDq2pNknfSFBMAp1TVmn7FKkmSJHVNX68sXFXnAOeMmndSz/2DN7LuGcAZ/YtOkiRJ6i6vLCxJkiR1UF+PCEiSpofFixczMjLCvHnzWLJkyaDDkSRtARYCkiRGRkZYvXr1oMOQJG1BFgKSNIMs/ODCSa03+97ZbMVW3HbvbZPaxrI3LJtUv5KkwXGMgCRJktRBHhGQJFHbFutYR2075gXgJUkzkIWAJIlHFj4y6BAkSVuYpwZJkiRJHWQhIEmSJHWQhYAkSZLUQRYCkiRJUgdZCEiSJEkdZCEgSZIkdZCFgCRJktRBFgKSJElSB1kISJIkSR1kISBJkiR1kIWAJEmS1EEWApIkSVIHbT3oACRJmm4WL17MyMgI8+bNY8mSJYMOR5ImxUJAkqQJGhkZYfXq1YMOQ5I2i4WAJKmzTn3rVya13r13Pfjzv5PZxgnvO2xS/UrSVHKMgCRJktRBHhGQJGmCtpu9w2P+StJ01NdCIMmhwN8Ds4CPVtW7Ry1/EfABYF/gmKo6u2fZo8DKdvLWqjq8n7FKkjReC5/2+4MOQZI2W98KgSSzgNOAlwKrgOVJllbVNT3NbgUWASeOsYmHqmq/fsUnSZIkdVk/jwgcANxQVTcBJDkLOAL4eSFQVTe3y9b1MQ5JkiRJo/RzsPCuwG0906vaeeO1TZIVSS5O8oqxGiQ5vm2z4s4779ycWCUNkLksTX/msTT99LMQyBjzagLr71FVC4A/BD6Q5Gm/tLGq06tqQVUtmDt37mTjlDRg5rI0/ZnH0vTTz0JgFbB7z/RuwO3jXbmqbm//3gRcAOw/lcFJkiRJXdbPQmA5MD/JXklmA8cAS8ezYpKdkjy+vb8LsJCesQWSJEmSNk/fCoGqWgucAJwHXAt8rqquTnJKksMBkjwvySrgKOAjSa5uV/9VYEWSK4BvAu8e9WtDkiRJkjZDX68jUFXnAOeMmndSz/3lNKcMjV7vO8A+/YxNkiRJ6rJ+nhokSZIkaUhZCEiSJEkdZCEgSZIkdVBfxwhIkiRJw2jx4sWMjIwwb948lixZMuhwBsJCQJIkSdPWqW/9yqTWu+7aG3nw4Xu5964HJ7WNE9532KT6HSaeGiRJkiR1kEcEJEmS1Dnbzd7hMX+7yEJAkiRJnbPwab8/6BAGzlODJEmSpA6yEJAkSZI6yEJAkiRJ6iALAUmSJKmDLAQkSZKkDrIQkCRJkjrIQkCSJEnqIAsBSZIkqYM2eEGxJPcDNdYioKqqu5dhkyRJkqa5DRYCVbX9lgxEkiRJ0pazwUJgtCRPBrZZP11Vt/YlIkmSJEl9t8kxAkkOT/JD4EfAhcDNwNf6HJckSZKkPhrPYOF3Ai8AflBVewEvAZb1NSpJkiRJfTWeQuCRqrob2CrJVlX1TWC/PsclSZIkqY/GM0bg3iRzgG8Bn0ryY2Btf8OSJEmS1E/jOSJwEfBE4C+Ac4EbgcP6GZQkSZKk/hpPIRDgPOACYA7w2fZUIUmSJEnT1CYLgar626p6NvDnwFOAC5P823g2nuTQJNcnuSHJ28dY/qIklyZZm+TIUcuOS/LD9nbcOB+PJEmSpHEYzxGB9X4MjAB3A0/eVOMks4DTgJcBewPHJtl7VLNbgUXAp0etuzPwDuD5wAHAO5LsNIFYJUmSJG3EeK4j8GdJLgC+AewC/ElV7TuObR8A3FBVN1XVz4CzgCN6G1TVzVV1JbBu1Lq/A5xfVWuq6h7gfODQcfQpSZIkaRzG86tBTwXeVFWXT3DbuwK39UyvotnDP9l1dx3dKMnxwPEAe+yxxwTDkzQszGVp+jOPpelnPGME3j6JIgCaQca/tLmpXLeqTq+qBVW1YO7cuRMKTtLwMJel6c88lqafiYwRmKhVwO4907sBt2+BdSVJkiRtQj8LgeXA/CR7JZkNHAMsHee65wGHJNmpHSR8SDtPkiRJ0hToWyFQVWuBE2i+wF8LfK6qrk5ySpLDAZI8L8kq4CjgI0mubtddA7yTpphYDpzSzpMkSZI0BcYzWHjSquoc4JxR807qub+c5rSfsdY9Azijn/FJkiRJXdXPU4MkSZIkDSkLAUmSJKmDLAQkSZKkDrIQkCRJkjrIQkCSJEnqIAsBSZIkqYP6+vOhkqTHWrx4MSMjI8ybN48lS5YMOhxJUodZCEjSFjQyMsLq1asHHYYkSRYCkjQZt56yz6TWW7tmZ2Br1q65ZVLb2OOklZPqV5Kk0RwjIEmSJHWQRwQkaQvaZZt1wNr2ryRJg2MhIElb0In73jvoECRJAjw1SJIkSeokCwFJkiSpgywEJEmSpA6yEJAkSZI6yEJAkiRJ6iALAUmSJKmDLAQkSZKkDrIQkCRJkjrIQkCSJEnqIAsBSZIkqYMsBCRJkqQOshCQJEmSOqivhUCSQ5Ncn+SGJG8fY/njk3y2Xf69JHu28/dM8lCSy9vbh/sZpyRJktQ1W/drw0lmAacBLwVWAcuTLK2qa3qavQ64p6qenuQY4D3A0e2yG6tqv37FJ0mSuu3WU/YZSL97nLRyIP1Ko/XziMABwA1VdVNV/Qw4CzhiVJsjgE+0988GXpIkfYxJkiRJEv0tBHYFbuuZXtXOG7NNVa0F7gOe1C7bK8llSS5M8ptjdZDk+CQrkqy48847pzZ6SVuMuSxNf+axNP30sxAYa89+jbPNHcAeVbU/8Bbg00l2+KWGVadX1YKqWjB37tzNDljSYJjL0vRnHkvTTz8LgVXA7j3TuwG3b6hNkq2BHYE1VfVwVd0NUFWXADcCz+hjrJIkSVKn9LMQWA7MT7JXktnAMcDSUW2WAse1948E/r2qKsncdrAxSf4rMB+4qY+xSpIkSZ3St18Nqqq1SU4AzgNmAWdU1dVJTgFWVNVS4GPAJ5PcAKyhKRYAXgSckmQt8Cjw+qpa069YJUmSpK7pWyEAUFXnAOeMmndSz/2fAkeNsd4XgC/0MzZJkiSpy7yysCRJktRBFgKSJElSB/X11CBJGpTFixczMjLCvHnzWLJkyaDDkSRp6FgISJqRRkZGWL169aDDkCRpaFkISBpqz33bmZNab/u77mcWcOtd909qG5e899WT6leSpOnCQkDSjLRu9naP+StJkh7LQkDSjPTg/EMGHYKk1mSP7G0uj+xJG+evBkmSJEkdZCEgSZIkdZCFgCRJktRBjhEQAAs/uHBgfS97w7KB9S1JktRVHhGQJEmSOshCQJIkSeogCwFJkiSpgywEJEmSpA6yEJAkSZI6yEJAkiRJ6iB/PlSahFPf+pWB9X3C+w4bWN+SJGnm8IiAJEmS1EEWApIkSVIHWQhIkiRJHWQhIEmSJHWQhYAkSZLUQRYCkiRJUgf586Fb2K2n7DOwvvc4aeXA+pYkSdJw6WshkORQ4O+BWcBHq+rdo5Y/HjgTeC5wN3B0Vd3cLvsr4HXAo8Abq+q8ifT93LedudnxT9Yl7331wPqWJEkaJosXL2ZkZIR58+axZMmSQYejHn0rBJLMAk4DXgqsApYnWVpV1/Q0ex1wT1U9PckxwHuAo5PsDRwDPBt4CvBvSZ5RVY/2K15JkiRNvZGREVavXj3oMDSGfh4ROAC4oapuAkhyFnAE0FsIHAGc3N4/Gzg1Sdr5Z1XVw8CPktzQbu+7fYxXktQnF77oxQPp98UXXTiQfqWZaLJ5/NDWsyDhoVWrJrUN87h/UlX92XByJHBoVf1xO/0q4PlVdUJPm6vaNqva6RuB59MUBxdX1b+08z8GfK2qzh7Vx/HA8e3kM4Hrpyj8XYC7pmhbU8m4Jsa4JmYq47qrqg4db2NzeWgY18R0Ia5x57J5PDSMa2K6ENcG87ifRwQyxrzRVceG2oxnXarqdOD0iYe2cUlWVNWCqd7u5jKuiTGuiRlkXObycDCuiTGuxzKPh4NxTUzX4+rnz4euAnbvmd4NuH1DbZJsDewIrBnnupIkSZImqZ+FwHJgfpK9ksymGfy7dFSbpcBx7f0jgX+v5lylpcAxSR6fZC9gPvD9PsYqSZIkdUrfTg2qqrVJTgDOo/n50DOq6uokpwArqmop8DHgk+1g4DU0xQJtu8/RDCxeC/z5Fv7FoCk/tDlFjGtijGtihjWuzTGsj8m4Jsa4JmZY45qsYX08xjUxxjUxWySuvg0WliRJkjS8+nlqkCRJkqQhZSEgSZIkdVBnC4Ekv5ekkjyrnd6zva7B6HYvSPK9JJcnuTbJyX2K59G2jyuSXJrkhe38pyQ5e1Pr90uSB0ZNvznJT5Ps2DPvoCRfHWPd301yWfuYrknyp1si5rbvB9q/Y/5f+9z3+v/lVUk+n2TbLdn/poz1nCQ5OcmJSS5IsmBjbYfNMOWyeTy1BpnHbb9Dm8vmcfc+k83jSfc/tHkMg8/lzhYCwLHAt2kHKG/EJ4Djq2o/4DnA5/oUz0NVtV9V/RrwV8C7AKrq9qo6sk99TsaxNL8I9Xsba5TkcTQDXQ5rH9P+wAV9j244rP9fPgf4GfD6QQc0ww1TLpvHM4u5vOUMUx7D9Mhl83h8zOON6GQhkGQOsBB4HZt+03kycAdAVT1aVdf0OTyAHYB74LHVX3v/W+3eid49FL+S5KKeivc3+xFUkqcBc4D/RfMGtDHb0/wq1d0AVfVwVU3VVSank28BTwdI8pb2/3NVkje18/ZMcl2STyS5MsnZw7a3YpgNeS6bxzOLudwnQ57HMIS5bB5Pmnk8SicLAeAVwLlV9QNgTZJf30jb9wPXJ/lSkj9Nsk2fYnpC+6ZxHfBR4J1jtPkx8NKq+nXgaOAf2vl/CJzX7iH5NeDyPsV4LPAZmkR6ZpInb6hhVa2huR7ELUk+k+SVSTr1ektzkbyXASuTPBd4DfB84AXAnyTZv236TOD0qtoX+E/gfwwi3mlq2HLZPJ6BzOW+G7Y8huHPZfN4gszjsXXuhdA6FjirvX8WG6mmq+oUYAHwdZrkPrdPMa0/dPUs4FDgzCQZ1eZxwD8lWQl8Hti7nb8ceE2acyX3qar7+xTjMcBZVbUO+CJw1MYaV9UfAy+huRjcicAZfYpr2DwhyeXACuBWmutlHAh8qaoerKoHaJ6/9XuJbquqZe39f2nb9tOGfjO4NrBsmH9jeNhy2TyeWYY5l83jbn8mm8fjN8x5DAPO5b5dUGxYJXkS8NvAc5IUzcXOCvjQhtapqhuBf0zyT8CdSZ5UVXf3K8aq+m6SXYC5oxa9GfgPmj0MWwE/bdtflORFwMtpLtD23qo6cypjSrIvzRWez2/fC2cDNwGnbeKxrKSpvj8J/AhYNJVxDamH2j1BPzfGB0iv0Und7w/su4GdRs3bmeb/M3rZzsBdfY5nUoY9l83jGWGYc9k87uhnsnk8YcOcxzDgXO7iEYEjgTOr6qlVtWdV7U7zZO82VuMkL+95wcwHHgXu7WeAaX41YRbt+Xw9dgTuaPcAvKptQ5KnAj+uqn+iqXQ3dlh1so4FTm6fsz2r6inArm3fYz2GOUkO6pm1H3BLH+KaLi4CXpFk2yTb0Qzu+la7bI8kv9HeXz9grm/avR93JHkJQJKdafZ4fZtmANkf9bzmjwO+2c94NsNQ57J5PGMNRS6bx0B3P5PN4803FHkMg8/lzh0RoPmnvnvUvC8Af01znt2qnvlvBv4AeH+SnwBrgVdW1aN9iGv9oSuAAMdV1aOjitYPAV9IchTNC+HBdv5BwNuSPAI8ALy6D/EdQ3NuXa8vtfO/B7xk1HN3LLA4yUeAh9pYF/Uhrmmhqi5N8nGaw7IAH62qy5LsCVwLHNc+Vz8E/nELhPRq4LQk72un/7aqbkxyOvAs4Ip279wKml/MGEbDmMvm8Qw3ZLlsHnfzM9k83kxDlscwwFxO1TCfNijNbO2bzlfbnzWTNE2Zy9L018U87uKpQZIkSVLneURAkiRJ6iCPCEiSJEkdZCEgSZIkdZCFgCRJktRBFgKaMklubi+6MhXben2SV7f3FyV5Sj/6kfRY5rE0M5jLGo8uXkdAQy7J1lX14Z5Zi4CrgNsHE5GkiTKPpZnBXJ7ZLAQ0KUn+Fdgd2Ab4+6o6fdTyvwFeCdxGcznsS6rq75LsB3wY2Ba4EXhtVd2T5ALgO8BCYGmS7WkuxHIzsAD4VJKHgPVX+3tDksOAxwFHVdV1SU4G9gJ+BXgG8BbgBTQXXlkNHFZVj/Th6ZCmJfNYmhnMZU2WpwZpsl5bVc+leUN4Y5InrV+QZAHN1R/3B36/bbPemcBfVtW+wErgHT3LnlhVL66q9VfWo6rOprmS3iurar+qeqhddFdV/TrNFf9O7NnG04CXA0cA/wJ8s6r2obma4sun4HFLM4l5LM0M5rImxUJAk/XGJFcAF9PshZjfs+xA4MtV9VBV3Q98BSDJjjRvLBe27T4BvKhnvc9OoP8vtn8vAfbsmf+1dg/DSmAWcG47f+WodpLMY2mmMJc1KZ4apAlLchBwMPAbVfWT9hDiNr1NJrnpByfQ9uH276M89nX8MEBVrUvySP3iinnr8PUu/Zx5LM0M5rI2h0cENBk7Ave0bzjPojnnr9e3gcOSbJNkDu3hv6q6D7gnyW+27V4FXMim3Q9sPzWhS2qZx9LMYC5r0qzGNBnnAq9PciVwPc2hyJ+rquVJlgJXALfQnE94X7v4OODDSbYFbgJeM47+Pt6u0zswSdLmMY+lmcFc1qTlF0dppKmTZE5VPdC+uVwEHF9Vlw46LknjZx5LM4O5rA3xiID65fQke9Ocp/gJ33Ckack8lmYGc1lj8oiAJEmS1EEOFpYkSZI6yEJAkiRJ6iALAUmSJKmDLAQkSZKkDrIQkCRJkjro/wN1nM6Br/tQyQAAAABJRU5ErkJggg==\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAwIAAADQCAYAAAC0otYBAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjMsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+AADFEAAAegUlEQVR4nO3de7hcdX3v8feHYOQSRJDYFAXhKGhRKNSI1lilVSkei9gWD1CrRG2pPUXrBVN7Q4rnOWqsR1vBKlWqWBQVtUYPgtSKaLwlcgdBLnJJcFcgYAURCfn2j7Wiw3Yn2Xv2nszsvd6v55lnz1rrt9bvO7PnOzPftdZvVqoKSZIkSd2yzbADkCRJkrT1WQhIkiRJHWQhIEmSJHWQhYAkSZLUQRYCkiRJUgdZCEiSJEkdZCGgCSU5MMn/3MzyxUn+cWvGNF1bijnJ7knO3poxSZI0U2bDZ3eSpUlOGWYM+jkLAW3KgcCEbyZJtq2q1VX16q0cU28MSTKl1++WYq6qW6vqyOlHJw3PbPgisClJXpnkpUPq+8Ykuw2jb2kGjfRnt0aPhcAclWSvJFcneX+SK5KcmeQ5SVYmuTbJwW27HZOcnmRVkouTHJFkPnAycFSSS5IcleSkJKcl+QJwRpJDknyu3caCJP+S5PIklyX5/WnGvjTJZ5Kcm+SaJG/qeUzfSfIe4CJgjySHJvl6kouSfCLJgrbtU5J8LcmlSb6VZKdxMT+rfWyXtI97p3b7V7TLt+t5TBcn+c2e2D7VxnZtkuXTeazSAIzEF4Ek2051nap6b1WdsbX7lUbFHPjsnvDzMcnLknw3yZeBJT3zfynJp9vP6kuTPL2d/7ft83B+ko8mOWE6sWkzqsrbHLwBewHrgf1pCr5vA6cDAY4A/q1t93+BP2zvPxz4LrAjsBQ4pWd7J7Xb2L6dPgT4XHv/bcC7etruMkE87wQumeD2xgnaLgW+DzwC2B64AljcPqYNwNPadrsBFwI7ttN/AZwIzAduAJ7Szn8YsO24mD8LLGnvL2iX7wVc0c57PfAv7f0nADcD27Wx3QDs3E7fBOwx7P+3t7lza1+HVwPvb1/7ZwLPAVYC1wIHt+12bHN6FXBxm9fz29fqbW1+HdXm7mnAF4CPjMuDBcC/AJcDlwG/P83YlwKfaPPrP9p5b2hjvAz4u562L23nXQp8uJ13EnBCe/8C4F3A19rn4eDN9Dv+Me4FfIVmh8FFwNPbdoe02z27fY7PBNIuu7F9T9keOBf442G/Frx178bs/+z+hc9H4Jfb96WF7XvUyo0xAh8DXtPen9euu7jtY3tgJ5r3vROG/b+Zqzf3nMxt36uqywGSXAl8saoqyeU0bzYAhwIv6Km2twP23MT2VlTVvRPMfw5w9MaJqrpzfIOqeu0UYz+/qu5oY/8U8Azg34CbquobbZunAfsBK5NA8wbzdeDxwPeralXb93+12+nd/krg/yU5E/hUVa0Zt/wZwLvb9a9OchOwb7vsi1X1w3abVwGPAW6Z4uOTNudxwIuA42i+RP8BzWvyBcBfAS8E/prmy/bLkzwc+Bbw7zTF8OKqOh4gyUnAk4FnVNW9SQ7p6edvgR9W1f5t213GB5LkncBvThDjWVX11gnm/zpwQFWtS3IosA9wMM0XmRVJngnc0ca/pKpuT7LrJp6HHavq6e06pwNP2kQ7xj3GHYDnVtVPkuwDfJTmywXAQcATgVtp3geWAF9tly0AzgLOqGkemZCmYTZ/dk/0+bgbcEFV3dbO/xg//zz9LZqdAlTVA8APkzwD+MzGmJN8dooxaAosBOa2+3rub+iZ3sDP//eh2Qt4Te+KSZ46wfbu2UQ/AWpzgfTxZWL89jZO98YQmoLhmHF9HbCleKrqrUn+P80pFN9I8hzgJ+O2vSm9z+sDmEeaebP5i8D5VbWuJ8ZDaY5YQPNFex/gV4Gzq+r2to91v7CVxkfb5RcmeViSh1fVXZto2/sYHwKckuRAmhzdt6fdt6pqDUCSS2iez42FwGeA5VV15qQfrTTzZvNn96Y+HzfbzwRxaStxjIDOA16Vdnd4koPa+T+iOSQ3GV8Ajt84MdFexap6bVUdOMFtojcSgOcm2TXJ9jR7P1dO0OYbwJIkj2v73SHJvjSH/HdP8pR2/k7jzxtO8tiquryq3gaspjn9p9eFwIvbtvvSfMG6BmnrmMoXgY25tGdVfWcT25vWF4Ge8TS9tzdOoq8Ab+mJ8XFV9YHJ9Nva1A6BLfX7WuA/aQqOxTRHCzfaXCG/EnjexvdDaYSN6mf3RL4JHJLkEUkeQnO0c6MvAn/a9j8vycNoCvPD04zVWwA8fwp9aYosBPRmmr1nl6UZKPvmdv6XgP02Djjawjb+D7BLO7DpUibeezBVXwU+THOe4CeravX4Bu1hxqXAR5NcRlMYPKGqfkpzbvS723jOp9lb2us1PfHeC3x+3PL3APPaPbAfA5ZW1X1Io2M2fBE4D3h5fj6I/1FJHknz4f+/kjyinb+pU4OOapc/g+YUph9O8nHtTHN64AbgJTTnHk/GiTSnLb1nku2lYRnVz+5fUFXfpxmr8HWa0xcv6ln858Bvtp+13wae2J7Wu4Jm/NCnaHbWTTb3NUUbB0lJIyPJUnrOcZa6JMleNIP5ntROf7CdPrt3WXu07F3A02n2sN9YVb/Tfqk+j+ZLwluAXwHurqq/b7d3CM3Au99pv6CfSnN+/QM0g3k/NY3YlzIud5P8OfBH7eTdNAMcr09yLM1A4geAi6tqaTue4e6q+vskF9B8cXgWzYD/l1fVtzbR78/Wa6f3AT4J/Jjmi9GrqmpB72Nv250CrK6qDya5kebowR004xFuq6pl/T4XkvqXZEFV3d2O97kQOK6qLtrSepo6CwGNHAsBSW0hcMJERwMlzW1JPkLzYyDbAR+qqrcMOaQ5y0JAkjRyLAQkafAsBCRJs0KSl9GcU9xrZVX92TDikaTZzkJAkiRJ6qA58/vnhx12WJ177rnDDkNSo++fXzSXpZHSVy6bx9JI2WQez5mfD7399tuHHYKkGWAuS7OfeSzNDnOmEJAkSZI0eRYCkiRJUgdZCEiSJEkdZCEgSZIkdZCFgCRJktRBc+bnQyVJkrps2bJljI2NsWjRIpYvXz7scDQLWAhIkiSNkCXvXtLXevOvns8292zDLXfd0tc2Vr5qZV/9avby1CBJkiSpgzwiIEmSNAfUDsUGNlA71LBD0SxhISBJkjQH3L/k/mGHoFlmoKcGJTksyTVJrkvyxgmWvy7JVUkuS/LFJI/pWXZskmvb27GDjFOSJEnqmoEVAknmAacCzwP2A45Jst+4ZhcDi6vqAOBsYHm77q7Am4CnAgcDb0qyy6BilSRJkrpmkEcEDgauq6obquqnwFnAEb0NqupLVfXjdvIbwKPb+78NnF9V66rqTuB84LABxipJkiR1yiALgUcBt/RMr2nnbcorgM9PZd0kxyVZnWT1bbfdNs1wJQ2LuSzNfuaxNPsMshDIBPMmHMae5A+BxcDbp7JuVZ1WVYuravHChQv7DlTScJnL0uxnHkuzzyALgTXAHj3TjwZuHd8oyXOAvwZeUFX3TWVdSZIkSf0ZZCGwCtgnyd5J5gNHAyt6GyQ5CHgfTRHwg55F5wGHJtmlHSR8aDtPkiRJ0gwY2HUEqmp9kuNpvsDPA06vqiuTnAysrqoVNKcCLQA+kQTg5qp6QVWtS/JmmmIC4OSqWjeoWCVJkqSuGegFxarqHOCccfNO7Ln/nM2sezpw+uCikyRJkrproBcUkyRJkjSaLAQkSZKkDhroqUGSpNlh2bJljI2NsWjRIpYvXz7scCRJW4GFgCSJsbEx1q5dO+wwJElbkYWAJM0hS969pK/15t81n23YhlvuuqWvbax81cq++pUkDY9jBCRJkqQO8oiAJInaodjABmqHGnYokqStxEJAksT9S+4fdgiSpK3MU4MkSZKkDrIQkCRJkjrIQkCSJEnqIAsBSZIkqYMsBCRJkqQOshCQJEmSOshCQJIkSeogCwFJkiSpgywEJEmSpA6yEJAkSZI6yEJAkiRJ6qBthx2AJEmzzbJlyxgbG2PRokUsX7582OFIUl8sBCRJmqKxsTHWrl077DAkaVosBCRJnXXK6z/b13p33X7Pz/72s43j33F4X/1K0kxyjIAkSZLUQR4RkCRpinac/7AH/ZWk2chCQJKkKVry2N8bdgiSNG0DPTUoyWFJrklyXZI3TrD8mUkuSrI+yZHjlj2Q5JL2tmKQcUqSJEldM7AjAknmAacCzwXWAKuSrKiqq3qa3QwsBU6YYBP3VtWBg4pPkiRJ6rJBnhp0MHBdVd0AkOQs4AjgZ4VAVd3YLtswwDgkSZIkjTPIU4MeBdzSM72mnTdZ2yVZneQbSV44UYMkx7VtVt92223TiVXSEJnL0uxnHkuzzyALgUwwr6aw/p5VtRj4A+BdSR77CxurOq2qFlfV4oULF/Ybp6QhM5el2c88lmafQRYCa4A9eqYfDdw62ZWr6tb27w3ABcBBMxmcJEmS1GWDLARWAfsk2TvJfOBoYFK//pNklyQPbe/vBiyhZ2yBJEmSpOkZWCFQVeuB44HzgO8AH6+qK5OcnOQFAEmekmQN8CLgfUmubFf/FWB1kkuBLwFvHfdrQ5IkSZKmYaAXFKuqc4Bzxs07sef+KppThsav9zVg/0HGJkmSJHXZQC8oJkmSJGk0WQhIkiRJHTTQU4MkSZKkUbRs2TLGxsZYtGgRy5cvH3Y4Q2EhIEmSpM4ZGxtj7dq1ww5jqCwEJEmSNGud8vrP9rXeXbff87O//Wzj+Hcc3le/o8RCQJIkSZ2z4/yHPehvF1kISJIkqXOWPPb3hh3C0PmrQZIkSVIHWQhIkiRJHWQhIEmSJHWQhYAkSZLUQRYCkiRJUgdZCEiSJEkdZCEgSZIkdZCFgCRJktRBFgKSJElSB23yysJJfgTURIuAqqruXo9ZkiRJmuU2WQhU1U5bMxBJkiRJW88mC4HxkjwS2G7jdFXdPJCIJEmSJA3cFscIJHlBkmuB7wFfBm4EPj/guCRJkiQN0GQGC78ZeBrw3araG3g2sHKgUUmSJEkaqMkUAvdX1R3ANkm2qaovAQcOOC5JkiRJAzSZMQJ3JVkAfAU4M8kPgPWDDUuSJEnSIE3miMCFwMOBPwfOBa4HDh9kUJIkSZIGazKFQIDzgAuABcDH2lOFtrxicliSa5Jcl+SNEyx/ZpKLkqxPcuS4Zccmuba9HTuZ/iRJkiRNzhYLgar6u6p6IvBnwO7Al5P8+5bWSzIPOBV4HrAfcEyS/cY1uxlYCnxk3Lq7Am8CngocDLwpyS5bfDSSJEmSJmUyRwQ2+gEwBtwBPHIS7Q8GrquqG6rqp8BZwBG9Darqxqq6DNgwbt3fBs6vqnVVdSdwPnDYFGKVJEmStBmTuY7Anya5APgisBvwx1V1wCS2/Sjglp7pNe28yZjOupIkSZK2YDK/GvQY4DVVdckUt50J5tVMrpvkOOA4gD333HPykUkaKeayNPuZx9LsM5kxAm/sowiAZi/+Hj3TjwZuncl1q+q0qlpcVYsXLlzYR4iSRoG5LM1+5rE0+0xljMBUrQL2SbJ3kvnA0cCKSa57HnBokl3aQcKHtvMkSZIkzYCBFQJVtR44nuYL/HeAj1fVlUlOTvICgCRPSbIGeBHwviRXtuuuA95MU0ysAk5u50mSJEmaAZMZI9C3qjoHOGfcvBN77q+iOe1nonVPB04fZHySJElSVw3y1CBJkiRJI8pCQJIkSeogCwFJkiSpgywEJEmSpA6yEJAkSZI6yEJAkiRJ6qCB/nyoJOnBli1bxtjYGIsWLWL58uXDDkeS1GEWApK0FY2NjbF27dphhyFJkoWAJPXj5pP372u99et2BbZl/bqb+trGnide3le/kiSN5xgBSZIkqYM8IiBJW9Fu220A1rd/JUkaHgsBSdqKTjjgrmGHIEkS4KlBkiRJUidZCEiSJEkdZCEgSZIkdZCFgCRJktRBFgKSJElSB1kISJIkSR1kISBJkiR1kIWAJEmS1EEWApIkSVIHWQhIkiRJHWQhIEmSJHWQhYAkSZLUQdsOOwBJkqTZZNmyZYyNjbFo0SKWL18+7HCkvg30iECSw5Jck+S6JG+cYPlDk3ysXf7NJHu18/dKcm+SS9rbewcZpyRJ0mSNjY2xdu1axsbGhh2KNC0DOyKQZB5wKvBcYA2wKsmKqrqqp9krgDur6nFJjgbeBhzVLru+qg4cVHySJKnbbj55/77WW79uV2Bb1q+7qa9t7Hni5X31K820QR4ROBi4rqpuqKqfAmcBR4xrcwTwofb+2cCzk2SAMUmSJE3Lbttt4Je2X89u220YdijStAxyjMCjgFt6ptcAT91Um6pan+SHwCPaZXsnuRj4L+Bvquor4ztIchxwHMCee+45s9FL2mrMZWn261Ien3DAXcMOQZoRgzwiMNGe/Zpkm+8De1bVQcDrgI8kedgvNKw6raoWV9XihQsXTjtgScNhLkuzn3kszT6DLATWAHv0TD8auHVTbZJsC+wMrKuq+6rqDoCq+jZwPbDvAGOVJEmSOmWQhcAqYJ8keyeZDxwNrBjXZgVwbHv/SOA/qqqSLGwHG5PkfwD7ADcMMFZJkiSpUwY2RqA95/944DxgHnB6VV2Z5GRgdVWtAD4AfDjJdcA6mmIB4JnAyUnWAw8Ar6yqdYOKVZIkSeqagV5QrKrOAc4ZN+/Envs/AV40wXqfBD45yNgkSZKkLhvoBcUkSZIkjaaBHhGQpGFZtmwZY2NjLFq0iOXLlw87HEmSRo6FgKQ5aWxsjLVr1w47DEmSRpaFgKSR9uQ3nNHXejvd/iPmATff/qO+tvHtt7+0r34lSZotLAQkzUkb5u/4oL+SJOnBLAQkzUn37HPosEOQJGmkWQhIkqSB6vcUv+nyFD9p8/z5UEmSJKmDLAQkSZKkDrIQkCRJkjrIMQICYMm7lwyt75WvWjm0viVJkrrKIwKSJElSB1kISJIkSR1kISBJkiR1kIWAJEmS1EEWApIkSVIHWQhIkiRJHeTPh0p9OOX1nx1a38e/4/Ch9S1JkuYOjwhIkiRJHWQhIEmSJHWQhYAkSZLUQRYCkiRJUgdZCEiSJEkdZCEgSZIkdZA/H7qV3Xzy/kPre88TLx9a35IkSRotAy0EkhwG/AMwD3h/Vb113PKHAmcATwbuAI6qqhvbZX8JvAJ4AHh1VZ03lb6f/IYzph1/v7799pcOrW9JkqRRsmzZMsbGxli0aBHLly8fdjjqMbBCIMk84FTgucAaYFWSFVV1VU+zVwB3VtXjkhwNvA04Ksl+wNHAE4HdgX9Psm9VPTCoeCVJkjTzxsbGWLt27bDD0AQGeUTgYOC6qroBIMlZwBFAbyFwBHBSe/9s4JQkaeefVVX3Ad9Lcl27va8PMF5J0oB8+ZnPGkq/z7rwy0PpV5qL+s3je7edBwn3rlnT1zbM48FJVQ1mw8mRwGFV9Uft9EuAp1bV8T1trmjbrGmnrweeSlMcfKOq/rWd/wHg81V19rg+jgOOaycfD1wzQ+HvBtw+Q9uaScY1NcY1NTMZ1+1VddhkG5vLI8O4pqYLcU06l83jkWFcU9OFuDaZx4M8IpAJ5o2vOjbVZjLrUlWnAadNPbTNS7K6qhbP9Hany7imxrimZphxmcujwbimxrgezDweDcY1NV2Pa5A/H7oG2KNn+tHArZtqk2RbYGdg3STXlSRJktSnQRYCq4B9kuydZD7N4N8V49qsAI5t7x8J/Ec15yqtAI5O8tAkewP7AN8aYKySJElSpwzs1KCqWp/keOA8mp8PPb2qrkxyMrC6qlYAHwA+3A4GXkdTLNC2+zjNwOL1wJ9t5V8MmvFDmzPEuKbGuKZmVOOajlF9TMY1NcY1NaMaV79G9fEY19QY19RslbgGNlhYkiRJ0uga5KlBkiRJkkaUhYAkSZLUQZ0tBJL8bpJK8oR2eq/2ugbj2z0tyTeTXJLkO0lOGlA8D7R9XJrkoiRPb+fvnuTsLa0/KEnuHjf92iQ/SbJzz7xDknxugnV/J8nF7WO6KsmfbI2Y277vbv9O+H8dcN8b/5dXJPlEkh22Zv9bMtFzkuSkJCckuSDJ4s21HTWjlMvm8cwaZh63/Y5sLpvH3ftMNo/77n9k8xiGn8udLQSAY4Cv0g5Q3owPAcdV1YHAk4CPDyiee6vqwKr6VeAvgbcAVNWtVXXkgPrsxzE0vwj1u5trlOQhNANdDm8f00HABQOPbjRs/F8+Cfgp8MphBzTHjVIum8dzi7m89YxSHsPsyGXzeHLM483oZCGQZAGwBHgFW37TeSTwfYCqeqCqrhpweAAPA+6EB1d/7f2vtHsnevdQ/HKSC3sq3t8YRFBJHgssAP6G5g1oc3ai+VWqOwCq6r6qmqmrTM4mXwEeB5Dkde3/54okr2nn7ZXk6iQfSnJZkrNHbW/FKBvxXDaP5xZzeUBGPI9hBHPZPO6beTxOJwsB4IXAuVX1XWBdkl/bTNt3Atck+XSSP0my3YBi2r5907gaeD/w5gna/AB4blX9GnAU8I/t/D8Azmv3kPwqcMmAYjwG+ChNIj0+ySM31bCq1tFcD+KmJB9N8uIknXq9pblI3vOAy5M8GXgZ8FTgacAfJzmobfp44LSqOgD4L+B/DyPeWWrUctk8noPM5YEbtTyG0c9l83iKzOOJde6F0DoGOKu9fxabqaar6mRgMfAFmuQ+d0AxbTx09QTgMOCMJBnX5iHAPye5HPgEsF87fxXwsjTnSu5fVT8aUIxHA2dV1QbgU8CLNte4qv4IeDbNxeBOAE4fUFyjZvsklwCrgZtprpfxDODTVXVPVd1N8/xt3Et0S1WtbO//a9t2kDb1m8G1iWWj/BvDo5bL5vHcMsq5bB53+zPZPJ68Uc5jGHIuD+yCYqMqySOA3wKelKRoLnZWwHs2tU5VXQ/8U5J/Bm5L8oiqumNQMVbV15PsBiwct+i1wH/S7GHYBvhJ2/7CJM8Enk9zgba3V9UZMxlTkgNorvB8fvteOB+4ATh1C4/lcprq+8PA94ClMxnXiLq33RP0MxN8gPQan9SD/sC+A9hl3Lxdaf4/45ftCtw+4Hj6Muq5bB7PCaOcy+ZxRz+TzeMpG+U8hiHnchePCBwJnFFVj6mqvapqD5on+9ETNU7y/J4XzD7AA8Bdgwwwza8mzKM9n6/HzsD32z0AL2nbkOQxwA+q6p9pKt3NHVbt1zHASe1ztldV7Q48qu17osewIMkhPbMOBG4aQFyzxYXAC5PskGRHmsFdX2mX7Znk19v7GwfMDUy79+P7SZ4NkGRXmj1eX6UZQPaHPa/5Y4EvDTKeaRjpXDaP56yRyGXzGOjuZ7J5PH0jkccw/Fzu3BEBmn/qW8fN+yTwVzTn2a3pmf9a4PeBdyb5MbAeeHFVPTCAuDYeugIIcGxVPTCuaH0P8MkkL6J5IdzTzj8EeEOS+4G7gZcOIL6jac6t6/Xpdv43gWePe+6OAZYleR9wbxvr0gHENStU1UVJPkhzWBbg/VV1cZK9gO8Ax7bP1bXAP22FkF4KnJrkHe3031XV9UlOA54AXNrunVtN84sZo2gUc9k8nuNGLJfN425+JpvH0zRieQxDzOVUjfJpg9Lc1r7pfK79WTNJs5S5LM1+XczjLp4aJEmSJHWeRwQkSZKkDvKIgCRJktRBFgKSJElSB1kISJIkSR1kIaAZk+TG9qIrM7GtVyZ5aXt/aZLdB9GPpAczj6W5wVzWZHTxOgIacUm2rar39sxaClwB3DqciCRNlXkszQ3m8txmIaC+JPk3YA9gO+Afquq0ccv/FngxcAvN5bC/XVV/n+RA4L3ADsD1wMur6s4kFwBfA5YAK5LsRHMhlhuBxcCZSe4FNl7t71VJDgceAryoqq5OchKwN/DLwL7A64Cn0Vx4ZS1weFXdP4CnQ5qVzGNpbjCX1S9PDVK/Xl5VT6Z5Q3h1kkdsXJBkMc3VHw8Cfq9ts9EZwF9U1QHA5cCbepY9vKqeVVUbr6xHVZ1NcyW9F1fVgVV1b7vo9qr6NZor/p3Qs43HAs8HjgD+FfhSVe1PczXF58/A45bmEvNYmhvMZfXFQkD9enWSS4Fv0OyF2Kdn2TOAz1TVvVX1I+CzAEl2pnlj+XLb7kPAM3vW+9gU+v9U+/fbwF498z/f7mG4HJgHnNvOv3xcO0nmsTRXmMvqi6cGacqSHAI8B/j1qvpxewhxu94mfW76nim0va/9+wAPfh3fB1BVG5LcXz+/Yt4GfL1LP2MeS3ODuazp8IiA+rEzcGf7hvMEmnP+en0VODzJdkkW0B7+q6ofAncm+Y223UuAL7NlPwJ2mpnQJbXMY2luMJfVN6sx9eNc4JVJLgOuoTkU+TNVtSrJCuBS4Caa8wl/2C4+Fnhvkh2AG4CXTaK/D7br9A5MkjQ95rE0N5jL6lt+fpRGmjlJFlTV3e2by4XAcVV10bDjkjR55rE0N5jL2hSPCGhQTkuyH815ih/yDUealcxjaW4wlzUhjwhIkiRJHeRgYUmSJKmDLAQkSZKkDrIQkCRJkjrIQkCSJEnqIAsBSZIkqYP+G0yR3EiylBbiAAAAAElFTkSuQmCC\n",
       "text/plain": [
        "<Figure size 777.6x216 with 3 Axes>"
       ]
@@ -713,10 +713,10 @@
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.075086,
-     "end_time": "2020-03-23T16:38:50.173245",
+     "duration": 0.018512,
+     "end_time": "2020-03-24T21:54:48.218852",
      "exception": false,
-     "start_time": "2020-03-23T16:38:50.098159",
+     "start_time": "2020-03-24T21:54:48.200340",
      "status": "completed"
     },
     "tags": []
@@ -729,10 +729,10 @@
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.042871,
-     "end_time": "2020-03-23T16:38:50.261893",
+     "duration": 0.017769,
+     "end_time": "2020-03-24T21:54:48.254567",
      "exception": false,
-     "start_time": "2020-03-23T16:38:50.219022",
+     "start_time": "2020-03-24T21:54:48.236798",
      "status": "completed"
     },
     "tags": []
@@ -745,10 +745,10 @@
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.064421,
-     "end_time": "2020-03-23T16:38:50.370095",
+     "duration": 0.017977,
+     "end_time": "2020-03-24T21:54:48.290522",
      "exception": false,
-     "start_time": "2020-03-23T16:38:50.305674",
+     "start_time": "2020-03-24T21:54:48.272545",
      "status": "completed"
     },
     "tags": []
@@ -761,10 +761,10 @@
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.075038,
-     "end_time": "2020-03-23T16:38:50.511270",
+     "duration": 0.017824,
+     "end_time": "2020-03-24T21:54:48.326618",
      "exception": false,
-     "start_time": "2020-03-23T16:38:50.436232",
+     "start_time": "2020-03-24T21:54:48.308794",
      "status": "completed"
     },
     "tags": []
@@ -779,10 +779,10 @@
    "execution_count": 15,
    "metadata": {
     "papermill": {
-     "duration": 24.475976,
-     "end_time": "2020-03-23T16:39:15.063190",
+     "duration": 9.186021,
+     "end_time": "2020-03-24T21:54:57.530517",
      "exception": false,
-     "start_time": "2020-03-23T16:38:50.587214",
+     "start_time": "2020-03-24T21:54:48.344496",
      "status": "completed"
     },
     "tags": []
@@ -792,7 +792,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Statistics=280110.888, p=0.000\n"
+      "Statistics=279997.458, p=0.000\n"
      ]
     }
    ],
@@ -811,10 +811,10 @@
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.044146,
-     "end_time": "2020-03-23T16:39:15.151906",
+     "duration": 0.020054,
+     "end_time": "2020-03-24T21:54:57.571873",
      "exception": false,
-     "start_time": "2020-03-23T16:39:15.107760",
+     "start_time": "2020-03-24T21:54:57.551819",
      "status": "completed"
     },
     "tags": []
@@ -827,10 +827,10 @@
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.078746,
-     "end_time": "2020-03-23T16:39:15.323900",
+     "duration": 0.019806,
+     "end_time": "2020-03-24T21:54:57.611664",
      "exception": false,
-     "start_time": "2020-03-23T16:39:15.245154",
+     "start_time": "2020-03-24T21:54:57.591858",
      "status": "completed"
     },
     "tags": []
@@ -843,10 +843,10 @@
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.077309,
-     "end_time": "2020-03-23T16:39:15.480741",
+     "duration": 0.019584,
+     "end_time": "2020-03-24T21:54:57.650737",
      "exception": false,
-     "start_time": "2020-03-23T16:39:15.403432",
+     "start_time": "2020-03-24T21:54:57.631153",
      "status": "completed"
     },
     "tags": []
@@ -862,10 +862,10 @@
    "execution_count": 16,
    "metadata": {
     "papermill": {
-     "duration": 0.258295,
-     "end_time": "2020-03-23T16:39:15.815943",
+     "duration": 0.083486,
+     "end_time": "2020-03-24T21:54:57.753451",
      "exception": false,
-     "start_time": "2020-03-23T16:39:15.557648",
+     "start_time": "2020-03-24T21:54:57.669965",
      "status": "completed"
     },
     "tags": []
@@ -875,12 +875,18 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "('ALS', 'Bias'), Statistics=120500226.500, p-value=0.000, Metric is different (reject H0)\n",
-      "('ALS', 'IALS'), Statistics=77610585.000, p-value=0.000, Metric is different (reject H0)\n",
-      "('ALS', 'II'), Statistics=11840796.500, p-value=0.000, Metric is different (reject H0)\n",
-      "('Bias', 'IALS'), Statistics=136628649.000, p-value=0.000, Metric is different (reject H0)\n",
-      "('Bias', 'II'), Statistics=13343494.000, p-value=0.000, Metric is different (reject H0)\n",
-      "('IALS', 'II'), Statistics=9297439.500, p-value=0.000, Metric is different (reject H0)\n"
+      "('ALS', 'Bias'), Statistics=116649279.000, p-value=0.000, Metric is different (reject H0)\n",
+      "('ALS', 'IALS'), Statistics=76466767.500, p-value=0.000, Metric is different (reject H0)\n",
+      "('ALS', 'II'), Statistics=12313277.000, p-value=0.000, Metric is different (reject H0)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "('Bias', 'IALS'), Statistics=135974064.000, p-value=0.000, Metric is different (reject H0)\n",
+      "('Bias', 'II'), Statistics=13854666.000, p-value=0.000, Metric is different (reject H0)\n",
+      "('IALS', 'II'), Statistics=10098407.000, p-value=0.000, Metric is different (reject H0)\n"
      ]
     }
    ],
@@ -907,10 +913,10 @@
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.077254,
-     "end_time": "2020-03-23T16:39:15.971846",
+     "duration": 0.019119,
+     "end_time": "2020-03-24T21:54:57.791352",
      "exception": false,
-     "start_time": "2020-03-23T16:39:15.894592",
+     "start_time": "2020-03-24T21:54:57.772233",
      "status": "completed"
     },
     "tags": []
@@ -923,10 +929,10 @@
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.077003,
-     "end_time": "2020-03-23T16:39:16.126267",
+     "duration": 0.019141,
+     "end_time": "2020-03-24T21:54:57.829784",
      "exception": false,
-     "start_time": "2020-03-23T16:39:16.049264",
+     "start_time": "2020-03-24T21:54:57.810643",
      "status": "completed"
     },
     "tags": []
@@ -939,10 +945,10 @@
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.076901,
-     "end_time": "2020-03-23T16:39:16.280998",
+     "duration": 0.019093,
+     "end_time": "2020-03-24T21:54:57.867559",
      "exception": false,
-     "start_time": "2020-03-23T16:39:16.204097",
+     "start_time": "2020-03-24T21:54:57.848466",
      "status": "completed"
     },
     "tags": []
@@ -957,10 +963,10 @@
    "execution_count": 17,
    "metadata": {
     "papermill": {
-     "duration": 24.843466,
-     "end_time": "2020-03-23T16:39:41.202328",
+     "duration": 8.971538,
+     "end_time": "2020-03-24T21:55:06.858151",
      "exception": false,
-     "start_time": "2020-03-23T16:39:16.358862",
+     "start_time": "2020-03-24T21:54:57.886613",
      "status": "completed"
     },
     "tags": []
@@ -970,7 +976,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Statistics=242622.335, p=0.000\n"
+      "Statistics=242046.619, p=0.000\n"
      ]
     }
    ],
@@ -989,10 +995,10 @@
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.077673,
-     "end_time": "2020-03-23T16:39:41.359093",
+     "duration": 0.019987,
+     "end_time": "2020-03-24T21:55:06.897503",
      "exception": false,
-     "start_time": "2020-03-23T16:39:41.281420",
+     "start_time": "2020-03-24T21:55:06.877516",
      "status": "completed"
     },
     "tags": []
@@ -1005,10 +1011,10 @@
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.077464,
-     "end_time": "2020-03-23T16:39:41.515964",
+     "duration": 0.018939,
+     "end_time": "2020-03-24T21:55:06.935503",
      "exception": false,
-     "start_time": "2020-03-23T16:39:41.438500",
+     "start_time": "2020-03-24T21:55:06.916564",
      "status": "completed"
     },
     "tags": []
@@ -1021,10 +1027,10 @@
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.077503,
-     "end_time": "2020-03-23T16:39:41.672029",
+     "duration": 0.018767,
+     "end_time": "2020-03-24T21:55:06.973409",
      "exception": false,
-     "start_time": "2020-03-23T16:39:41.594526",
+     "start_time": "2020-03-24T21:55:06.954642",
      "status": "completed"
     },
     "tags": []
@@ -1040,10 +1046,10 @@
    "execution_count": 18,
    "metadata": {
     "papermill": {
-     "duration": 0.378096,
-     "end_time": "2020-03-23T16:39:42.129081",
+     "duration": 0.151156,
+     "end_time": "2020-03-24T21:55:07.143761",
      "exception": false,
-     "start_time": "2020-03-23T16:39:41.750985",
+     "start_time": "2020-03-24T21:55:06.992605",
      "status": "completed"
     },
     "tags": []
@@ -1053,18 +1059,18 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "('ALS', 'Bias'), Statistics=396651290.000, p-value=0.000, Metric is different (reject H0)\n",
-      "('ALS', 'IALS'), Statistics=349845340.500, p-value=0.000, Metric is different (reject H0)\n",
-      "('ALS', 'II'), Statistics=10810454.500, p-value=0.000, Metric is different (reject H0)\n",
-      "('Bias', 'IALS'), Statistics=767328771.000, p-value=0.000, Metric is different (reject H0)\n",
-      "('Bias', 'II'), Statistics=11050771.000, p-value=0.000, Metric is different (reject H0)\n"
+      "('ALS', 'Bias'), Statistics=395382848.000, p-value=0.000, Metric is different (reject H0)\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "('IALS', 'II'), Statistics=13833471.500, p-value=0.000, Metric is different (reject H0)\n"
+      "('ALS', 'IALS'), Statistics=360411871.500, p-value=0.000, Metric is different (reject H0)\n",
+      "('ALS', 'II'), Statistics=11326265.000, p-value=0.000, Metric is different (reject H0)\n",
+      "('Bias', 'IALS'), Statistics=773770960.500, p-value=0.000, Metric is different (reject H0)\n",
+      "('Bias', 'II'), Statistics=11709997.000, p-value=0.000, Metric is different (reject H0)\n",
+      "('IALS', 'II'), Statistics=14593500.000, p-value=0.000, Metric is different (reject H0)\n"
      ]
     }
    ],
@@ -1091,10 +1097,10 @@
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.079546,
-     "end_time": "2020-03-23T16:39:42.288736",
+     "duration": 0.019653,
+     "end_time": "2020-03-24T21:55:07.182712",
      "exception": false,
-     "start_time": "2020-03-23T16:39:42.209190",
+     "start_time": "2020-03-24T21:55:07.163059",
      "status": "completed"
     },
     "tags": []
@@ -1107,10 +1113,10 @@
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.084766,
-     "end_time": "2020-03-23T16:39:42.461121",
+     "duration": 0.019195,
+     "end_time": "2020-03-24T21:55:07.221281",
      "exception": false,
-     "start_time": "2020-03-23T16:39:42.376355",
+     "start_time": "2020-03-24T21:55:07.202086",
      "status": "completed"
     },
     "tags": []
@@ -1123,10 +1129,10 @@
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.079484,
-     "end_time": "2020-03-23T16:39:42.621154",
+     "duration": 0.018902,
+     "end_time": "2020-03-24T21:55:07.259635",
      "exception": false,
-     "start_time": "2020-03-23T16:39:42.541670",
+     "start_time": "2020-03-24T21:55:07.240733",
      "status": "completed"
     },
     "tags": []
@@ -1141,10 +1147,10 @@
    "execution_count": 19,
    "metadata": {
     "papermill": {
-     "duration": 24.510353,
-     "end_time": "2020-03-23T16:40:07.212808",
+     "duration": 8.797745,
+     "end_time": "2020-03-24T21:55:16.076459",
      "exception": false,
-     "start_time": "2020-03-23T16:39:42.702455",
+     "start_time": "2020-03-24T21:55:07.278714",
      "status": "completed"
     },
     "tags": []
@@ -1154,7 +1160,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Statistics=218561.941, p=0.000\n"
+      "Statistics=217500.891, p=0.000\n"
      ]
     }
    ],
@@ -1173,10 +1179,10 @@
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.04777,
-     "end_time": "2020-03-23T16:40:07.308152",
+     "duration": 0.019936,
+     "end_time": "2020-03-24T21:55:16.117457",
      "exception": false,
-     "start_time": "2020-03-23T16:40:07.260382",
+     "start_time": "2020-03-24T21:55:16.097521",
      "status": "completed"
     },
     "tags": []
@@ -1189,10 +1195,10 @@
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.081301,
-     "end_time": "2020-03-23T16:40:07.436672",
+     "duration": 0.019247,
+     "end_time": "2020-03-24T21:55:16.156194",
      "exception": false,
-     "start_time": "2020-03-23T16:40:07.355371",
+     "start_time": "2020-03-24T21:55:16.136947",
      "status": "completed"
     },
     "tags": []
@@ -1205,10 +1211,10 @@
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.080898,
-     "end_time": "2020-03-23T16:40:07.599944",
+     "duration": 0.019265,
+     "end_time": "2020-03-24T21:55:16.194690",
      "exception": false,
-     "start_time": "2020-03-23T16:40:07.519046",
+     "start_time": "2020-03-24T21:55:16.175425",
      "status": "completed"
     },
     "tags": []
@@ -1224,10 +1230,10 @@
    "execution_count": 20,
    "metadata": {
     "papermill": {
-     "duration": 0.304841,
-     "end_time": "2020-03-23T16:40:07.985695",
+     "duration": 0.112664,
+     "end_time": "2020-03-24T21:55:16.326637",
      "exception": false,
-     "start_time": "2020-03-23T16:40:07.680854",
+     "start_time": "2020-03-24T21:55:16.213973",
      "status": "completed"
     },
     "tags": []
@@ -1237,12 +1243,18 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "('ALS', 'Bias'), Statistics=396039720.500, p-value=0.000, Metric is different (reject H0)\n",
-      "('ALS', 'IALS'), Statistics=859909518.000, p-value=0.000, Metric is different (reject H0)\n",
-      "('ALS', 'II'), Statistics=10145379.000, p-value=0.000, Metric is different (reject H0)\n",
-      "('Bias', 'IALS'), Statistics=1602626357.000, p-value=0.000, Metric is different (reject H0)\n",
-      "('Bias', 'II'), Statistics=8978385.000, p-value=0.000, Metric is different (reject H0)\n",
-      "('IALS', 'II'), Statistics=21088425.500, p-value=0.000, Metric is different (reject H0)\n"
+      "('ALS', 'Bias'), Statistics=400867296.000, p-value=0.000, Metric is different (reject H0)\n",
+      "('ALS', 'IALS'), Statistics=882413325.000, p-value=0.000, Metric is different (reject H0)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "('ALS', 'II'), Statistics=10136736.500, p-value=0.000, Metric is different (reject H0)\n",
+      "('Bias', 'IALS'), Statistics=1604513429.000, p-value=0.000, Metric is different (reject H0)\n",
+      "('Bias', 'II'), Statistics=9313117.500, p-value=0.000, Metric is different (reject H0)\n",
+      "('IALS', 'II'), Statistics=21680806.000, p-value=0.000, Metric is different (reject H0)\n"
      ]
     }
    ],
@@ -1269,10 +1281,10 @@
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.081915,
-     "end_time": "2020-03-23T16:40:08.155677",
+     "duration": 0.020039,
+     "end_time": "2020-03-24T21:55:16.366607",
      "exception": false,
-     "start_time": "2020-03-23T16:40:08.073762",
+     "start_time": "2020-03-24T21:55:16.346568",
      "status": "completed"
     },
     "tags": []
@@ -1288,10 +1300,10 @@
    "execution_count": 21,
    "metadata": {
     "papermill": {
-     "duration": 718.575285,
-     "end_time": "2020-03-23T16:52:06.813626",
+     "duration": 409.141509,
+     "end_time": "2020-03-24T22:02:05.528490",
      "exception": false,
-     "start_time": "2020-03-23T16:40:08.238341",
+     "start_time": "2020-03-24T21:55:16.386981",
      "status": "completed"
     },
     "tags": []
@@ -1307,10 +1319,10 @@
    "execution_count": 22,
    "metadata": {
     "papermill": {
-     "duration": 7.053061,
-     "end_time": "2020-03-23T16:52:13.943840",
+     "duration": 4.312729,
+     "end_time": "2020-03-24T22:02:09.864295",
      "exception": false,
-     "start_time": "2020-03-23T16:52:06.890779",
+     "start_time": "2020-03-24T22:02:05.551566",
      "status": "completed"
     },
     "tags": []
@@ -1319,7 +1331,7 @@
     {
      "data": {
       "text/plain": [
-       "<seaborn.axisgrid.FacetGrid at 0x7fb447f1b6d0>"
+       "<seaborn.axisgrid.FacetGrid at 0x2aaadfba8e50>"
       ]
      },
      "execution_count": 22,
@@ -1348,10 +1360,10 @@
    "execution_count": null,
    "metadata": {
     "papermill": {
-     "duration": 0.083365,
-     "end_time": "2020-03-23T16:52:14.106601",
+     "duration": 0.020407,
+     "end_time": "2020-03-24T22:02:09.905578",
      "exception": false,
-     "start_time": "2020-03-23T16:52:14.023236",
+     "start_time": "2020-03-24T22:02:09.885171",
      "status": "completed"
     },
     "tags": []
@@ -1379,8 +1391,8 @@
    "version": "3.7.6"
   },
   "papermill": {
-   "duration": 8457.227457,
-   "end_time": "2020-03-23T16:52:14.195655",
+   "duration": 5169.916337,
+   "end_time": "2020-03-24T22:02:09.931072",
    "environment_variables": {},
    "exception": null,
    "input_path": "eval-report.ipynb",
@@ -1388,7 +1400,7 @@
    "parameters": {
     "dataset": "ml20m"
    },
-   "start_time": "2020-03-23T14:31:16.968198",
+   "start_time": "2020-03-24T20:36:00.014735",
    "version": "2.0.0"
   }
  },

--- a/eval-report.ml20m.ipynb.dvc
+++ b/eval-report.ml20m.ipynb.dvc
@@ -1,22 +1,22 @@
-md5: 60c8ea5331388a61616a92d84b8d4033
+md5: 6b0ffa95c1cef286f59a0cfa25a23e81
 cmd: papermill -r dataset ml20m eval-report.ipynb eval-report.ml20m.ipynb
 deps:
 - path: output/ml20m-Bias
-  md5: f495c6bbe4998138f5599638aa83d75f.dir
+  md5: 4b1954ae4d3e283628bb1cc9dd3d4793.dir
 - path: output/ml20m-Pop
-  md5: b3f915316386f73e098f60917a04c4f0.dir
-- md5: acda85746fcf97381a54c6e27d13b67c.dir
+  md5: 89a8bb154944795fee0f28e59ab20ea7.dir
+- md5: 835431c782dc0b1893d123d77709a566.dir
   path: output/ml20m-ALS
-- md5: e1cc33f4046bd581b01f567e8db36912.dir
+- md5: 652d244cc78643fd86c15b412416665d.dir
   path: output/ml20m-IALS
-- md5: 2f777466b0a0b7eaa1686dd89a5c7a2c.dir
+- md5: 24e0f9682506ca9696f41f7a193803e6.dir
   path: output/ml20m-II
-- md5: 42a74ef32dc2b2d6faae94d94997ab62.dir
+- md5: c2662e081129987da8e281b22e9df255.dir
   path: output/ml20m-UU
-- md5: 22203b9e4f7df91bd5d6dc68cc09f7ce
+- md5: a8a899911433f2ef1f50722ea4707546
   path: eval-report.ipynb
 outs:
-- md5: 5abcf170253509652a883d300e267329
+- md5: d1af3f1b02ad532810921f15ad841dfd
   path: eval-report.ml20m.ipynb
   cache: false
   metric: false

--- a/lkdemo/datasets.py
+++ b/lkdemo/datasets.py
@@ -1,3 +1,5 @@
+import pandas as pd
+
 from lenskit import datasets as ds
 
 ml20m = ds.MovieLens('data/ml-20m')
@@ -8,3 +10,10 @@ ml10m = ds.ML10M('data/ml-10M100K')
 
 if hasattr(ds, 'BookCrossing'):
     bx = ds.BookCrossing('data/bx')
+
+
+def ds_diff(full, subset):
+    "Return the difference of two data sets."
+    mask = pd.Series(True, index=full.index)
+    mask[subset.index] = False
+    return full[mask]

--- a/output/ml100k-ALS.dvc
+++ b/output/ml100k-ALS.dvc
@@ -1,11 +1,11 @@
-md5: 9ebe68cd6c8ae69ac55db164898e678c
+md5: 6710f60a0bbadefc51e2ecc1d5288c0d
 cmd: python run-algo.py --splits data-split/ml100k -o output/ml100k-ALS ALS
 wdir: ..
 deps:
-- md5: bada8b5fc3b766ba8d9d44f3b7bb0809.dir
+- md5: c3ee128c9719ac7520f29b4f5aa74137.dir
   path: data-split/ml100k
 outs:
-- md5: 133fb6eb30f059665df9cdf11558b552.dir
+- md5: a61b739c076ecbdca30fb42d1845a7b9.dir
   path: output/ml100k-ALS
   cache: true
   metric: false

--- a/output/ml100k-Bias.dvc
+++ b/output/ml100k-Bias.dvc
@@ -1,11 +1,11 @@
-md5: 0bb3a723f0211074eccb109a0051a9dc
+md5: 7a6cf92d7e07c2b6eae919be666e8dc7
 cmd: python run-algo.py --splits data-split/ml100k -o output/ml100k-Bias Bias
 wdir: ..
 deps:
-- md5: bada8b5fc3b766ba8d9d44f3b7bb0809.dir
+- md5: c3ee128c9719ac7520f29b4f5aa74137.dir
   path: data-split/ml100k
 outs:
-- md5: f57cbf9baad88803d7a67ad4b317b388.dir
+- md5: 207481bbf294d0d5c8efa7f02d533941.dir
   path: output/ml100k-Bias
   cache: true
   metric: false

--- a/output/ml100k-IALS.dvc
+++ b/output/ml100k-IALS.dvc
@@ -1,11 +1,11 @@
-md5: a73ef2a068b3bd792307bb62eac89864
+md5: 609939269ef7c61619ca58a40e6d1d9e
 cmd: python run-algo.py --splits data-split/ml100k -o output/ml100k-IALS IALS
 wdir: ..
 deps:
-- md5: bada8b5fc3b766ba8d9d44f3b7bb0809.dir
+- md5: c3ee128c9719ac7520f29b4f5aa74137.dir
   path: data-split/ml100k
 outs:
-- md5: 17dbc4d3edf7860b1f5cee6700d711fc.dir
+- md5: fbfc5a89096a4642f911fc5f7482b32c.dir
   path: output/ml100k-IALS
   cache: true
   metric: false

--- a/output/ml100k-II.dvc
+++ b/output/ml100k-II.dvc
@@ -1,11 +1,11 @@
-md5: ab726d13d2d441e1d6585140452e9b05
+md5: 13854aa20728834972d1a1b319666a08
 cmd: python run-algo.py --splits data-split/ml100k -o output/ml100k-II II
 wdir: ..
 deps:
-- md5: bada8b5fc3b766ba8d9d44f3b7bb0809.dir
+- md5: c3ee128c9719ac7520f29b4f5aa74137.dir
   path: data-split/ml100k
 outs:
-- md5: be34a158cba6c257ab2f9ec168203cab.dir
+- md5: 391fda6fc3d54f2aeb676b4e01360c9c.dir
   path: output/ml100k-II
   cache: true
   metric: false

--- a/output/ml100k-Pop.dvc
+++ b/output/ml100k-Pop.dvc
@@ -1,11 +1,11 @@
-md5: 8b7c965540de536953fd09819788d9c3
+md5: e5e7d4d1c04a886e4769919243d2249f
 cmd: python run-algo.py --splits data-split/ml100k -o output/ml100k-Pop Pop
 wdir: ..
 deps:
-- md5: bada8b5fc3b766ba8d9d44f3b7bb0809.dir
+- md5: c3ee128c9719ac7520f29b4f5aa74137.dir
   path: data-split/ml100k
 outs:
-- md5: a31d3ba9d957b44c84a620e4680d700c.dir
+- md5: 9097cb72d506821f3838fb8f480074d5.dir
   path: output/ml100k-Pop
   cache: true
   metric: false

--- a/output/ml100k-UU.dvc
+++ b/output/ml100k-UU.dvc
@@ -1,11 +1,11 @@
-md5: 4015870f2ff35388e6327c5b66647367
+md5: 4dbbbc4d7667898427fe0d888d9af3b0
 cmd: python run-algo.py --splits data-split/ml100k -o output/ml100k-UU UU
 wdir: ..
 deps:
-- md5: bada8b5fc3b766ba8d9d44f3b7bb0809.dir
+- md5: c3ee128c9719ac7520f29b4f5aa74137.dir
   path: data-split/ml100k
 outs:
-- md5: 2c7fe862338a391b34da6bf1327d9f40.dir
+- md5: b6f5d09b288620a53a65f136b93fb546.dir
   path: output/ml100k-UU
   cache: true
   metric: false

--- a/output/ml20m-ALS.dvc
+++ b/output/ml20m-ALS.dvc
@@ -1,11 +1,11 @@
-md5: 8283c8a77db80af14a3ef7406016df68
+md5: 241654488647957022f7d8e5c6210ecb
 cmd: python run-algo.py --splits data-split/ml20m -o output/ml20m-ALS ALS
 wdir: ..
 deps:
-- md5: 2323819a1805e5d807209e1b9eb6f94c.dir
+- md5: 9c82e3dbd6aa78110a4b914d904b5060.dir
   path: data-split/ml20m
 outs:
-- md5: acda85746fcf97381a54c6e27d13b67c.dir
+- md5: 835431c782dc0b1893d123d77709a566.dir
   path: output/ml20m-ALS
   cache: true
   metric: false

--- a/output/ml20m-Bias.dvc
+++ b/output/ml20m-Bias.dvc
@@ -1,11 +1,11 @@
-md5: b856bf9462e081b1fe375c6d00ee8f05
+md5: 562792967e99c58a75f2d8f1d9836702
 cmd: python run-algo.py --splits data-split/ml20m -o output/ml20m-Bias Bias
 wdir: ..
 deps:
-- md5: 2323819a1805e5d807209e1b9eb6f94c.dir
+- md5: 9c82e3dbd6aa78110a4b914d904b5060.dir
   path: data-split/ml20m
 outs:
-- md5: f495c6bbe4998138f5599638aa83d75f.dir
+- md5: 4b1954ae4d3e283628bb1cc9dd3d4793.dir
   path: output/ml20m-Bias
   cache: true
   metric: false

--- a/output/ml20m-IALS.dvc
+++ b/output/ml20m-IALS.dvc
@@ -1,11 +1,11 @@
-md5: 092e0de8b1e391a034a32b1b3fed641e
+md5: d9c3bd80d0d09d03e4a7a0701c1c653b
 cmd: python run-algo.py --splits data-split/ml20m -o output/ml20m-IALS IALS
 wdir: ..
 deps:
-- md5: 2323819a1805e5d807209e1b9eb6f94c.dir
+- md5: 9c82e3dbd6aa78110a4b914d904b5060.dir
   path: data-split/ml20m
 outs:
-- md5: e1cc33f4046bd581b01f567e8db36912.dir
+- md5: 652d244cc78643fd86c15b412416665d.dir
   path: output/ml20m-IALS
   cache: true
   metric: false

--- a/output/ml20m-II.dvc
+++ b/output/ml20m-II.dvc
@@ -1,11 +1,11 @@
-md5: cc12135483c1c63768322febbb671170
+md5: 05e89373964260c83060d27cf4188f5c
 cmd: python run-algo.py --splits data-split/ml20m -o output/ml20m-II II
 wdir: ..
 deps:
-- md5: 2323819a1805e5d807209e1b9eb6f94c.dir
+- md5: 9c82e3dbd6aa78110a4b914d904b5060.dir
   path: data-split/ml20m
 outs:
-- md5: 2f777466b0a0b7eaa1686dd89a5c7a2c.dir
+- md5: 24e0f9682506ca9696f41f7a193803e6.dir
   path: output/ml20m-II
   cache: true
   metric: false

--- a/output/ml20m-Pop.dvc
+++ b/output/ml20m-Pop.dvc
@@ -1,11 +1,11 @@
-md5: fb311ec03281c391d7393fb9e78e23c3
+md5: 225314a123d7d0698e4c5918ac08bb10
 cmd: python run-algo.py --splits data-split/ml20m -o output/ml20m-Pop Pop
 wdir: ..
 deps:
-- md5: 2323819a1805e5d807209e1b9eb6f94c.dir
+- md5: 9c82e3dbd6aa78110a4b914d904b5060.dir
   path: data-split/ml20m
 outs:
-- md5: b3f915316386f73e098f60917a04c4f0.dir
+- md5: 89a8bb154944795fee0f28e59ab20ea7.dir
   path: output/ml20m-Pop
   cache: true
   metric: false

--- a/output/ml20m-UU.dvc
+++ b/output/ml20m-UU.dvc
@@ -1,11 +1,11 @@
-md5: 5c64391719a6798484d25b3f13761a37
+md5: 99472d45270a5899ce4517d5a2410912
 cmd: python run-algo.py --splits data-split/ml20m -o output/ml20m-UU UU
 wdir: ..
 deps:
-- md5: 2323819a1805e5d807209e1b9eb6f94c.dir
+- md5: 9c82e3dbd6aa78110a4b914d904b5060.dir
   path: data-split/ml20m
 outs:
-- md5: 42a74ef32dc2b2d6faae94d94997ab62.dir
+- md5: c2662e081129987da8e281b22e9df255.dir
   path: output/ml20m-UU
   cache: true
   metric: false

--- a/run-algo.py
+++ b/run-algo.py
@@ -79,12 +79,12 @@ for file in path.glob("test-*"):
     
     _log.info(f'generating recommendations for unique users')  
     users = test.user.unique()
-    recs = batch.recommend(fittable, users, n_recs)
+    recs = batch.recommend(fittable, users, n_recs, n_jobs=ncpus)
     _log.info(f'writing recommendations to {dest}')
     suffix = model + suffix
     recs.to_csv(dest / f'recs-{suffix}', index = False)
     
     if isinstance(fittable, Predictor):
         _log.info(f'generating predictions for user-item') 
-        preds = batch.predict(fittable, test)
+        preds = batch.predict(fittable, test, n_jobs=ncpus)
         preds.to_csv(dest / f'pred-{suffix}', index = False)

--- a/run-algo.py
+++ b/run-algo.py
@@ -17,7 +17,7 @@ from docopt import docopt
 from pathlib import Path
 from lenskit.algorithms import Recommender, Predictor
 from lenskit import batch, util
-from lkdemo import log
+from lkdemo import log, datasets
 
 import importlib
 import pandas as pd
@@ -48,25 +48,37 @@ path = Path(input)
 dest = Path(output)
 dest.mkdir(exist_ok=True , parents=True)
 
+ds_def = getattr(datasets, path.name, None)
+
 for file in path.glob("test-*"):
     test = pd.read_csv(file, sep=',')
     suffix = file.name[5:]
+    train_file = path / f'train-{suffix}'
+    
+    if 'index' in test.columns:
+        _log.info('setting test index')
+        test = test.set_index('index')
+    else:
+        _log.warn('no index column found in %s', file.name)
 
-    try:
+    if train_file.exists():
+        _log.info('loading training data from %s', train_file)
         train = pd.read_csv(path / f'train-{suffix}', sep=',')
-    except FileNotFoundError:
-        _log.error(f'train-{suffix} does not exists')
+    elif ds_def is not None:
+        _log.info('extracting training data from data set %s', path.name)
+        train = datasets.ds_diff(ds_def.ratings, test)
+        train.reset_index(drop=True, inplace=True)
+    else:
+        _log.error('could not find training data for %s', file.name)
         continue
-    
+
     _log.info('Fitting the model')
-    
-    users = test.user.unique()
-    
     fittable = util.clone(algo)
     fittable = Recommender.adapt(fittable)
     fittable.fit(train)
     
     _log.info(f'generating recommendations for unique users')  
+    users = test.user.unique()
     recs = batch.recommend(fittable, users, n_recs)
     _log.info(f'writing recommendations to {dest}')
     suffix = model + suffix
@@ -76,6 +88,3 @@ for file in path.glob("test-*"):
         _log.info(f'generating predictions for user-item') 
         preds = batch.predict(fittable, test)
         preds.to_csv(dest / f'pred-{suffix}', index = False)
-    
-
-

--- a/slurm-job.sh
+++ b/slurm-job.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+#SBATCH -n lkpy
+#SRUN -n lkpy
+
+node=$(hostname)
+echo "Running job on node $node" >&2
+
+# Boise State's SLURM cluster has aggresive ulimits, even with larger job requests
+# Reset those limits
+ulimit -v unlimited
+ulimit -u 1024
+
+# Configure LensKit threading based on SLURM
+cpus="$SLURM_CPUS_ON_NODE"
+
+if [ -z "$LK_NUM_PROCS" -a -n "$cpus" ]; then
+    # get proces from SLURM
+    procs=$(expr $cpus / 2)
+    if [[ $procs = 0 ]]; then
+        $procs=1
+    fi
+    echo "using $procs LK processes"
+    export LK_NUM_PROCS=$procs
+fi
+
+if [ -n "$cpus" ]; then
+    echo "using $cpus Numba threads"
+    export NUMBA_NUM_THREADS="$cpus"
+    export MKL_NUM_THREADS=1
+fi
+
+export MKL_THREADING_LAYER=tbb
+
+# Finally run the code
+exec "$@"

--- a/slurm-job.sh
+++ b/slurm-job.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-#SBATCH -n lkpy
-#SRUN -n lkpy
+#SBATCH -J lkpy
+#SRUN -J lkpy
 
 node=$(hostname)
 echo "Running job on node $node" >&2

--- a/split-data.py
+++ b/split-data.py
@@ -35,7 +35,10 @@ path.mkdir(exist_ok=True, parents=True)
 
 _log.info('writing to %s', path)
 testRowsPerUsers = 5
-for i, tp in enumerate(xf.partition_users(ratings, partitions, xf.SampleN(testRowsPerUsers)),1):
-    tp.train.to_csv(path / f'train-{i}.csv.gz', index=False)
-    tp.test.to_csv(path / f'test-{i}.csv.gz' , index=False)
+for i, tp in enumerate(xf.partition_users(ratings, partitions, xf.SampleN(testRowsPerUsers)), 1):
+    # _log.info('writing train set %d', i)
+    # tp.train.to_csv(path / f'train-{i}.csv.gz', index=False)
+    _log.info('writing test set %d', i)
+    tp.test.index.name = 'index'
+    tp.test.to_csv(path / f'test-{i}.csv.gz')
     


### PR DESCRIPTION
This PR significantly reduces the disk space required for running the experiment in two ways:

* Compressing intermediate CSV files
* Only storing test data in splits, computing the training data in memory from the ratings and test data

It also re-runs everything and makes some documentation updates.